### PR TITLE
Fixed video rendering stuck at 0% without webcam present/enabled

### DIFF
--- a/src/pages/RendererPage.tsx
+++ b/src/pages/RendererPage.tsx
@@ -205,11 +205,11 @@ export function RendererPage() {
 
           // Create seek promises for both videos
           const mainSeek = seekPromise(video)
-          const webcamSeek = webcamVideo ? seekPromise(webcamVideo) : Promise.resolve()
+          const webcamSeek = (hasWebcam && webcamVideo) ? seekPromise(webcamVideo) : Promise.resolve()
 
           // Set currentTime for both videos to trigger seeking
           video.currentTime = sourceTimestamp
-          if (webcamVideo) {
+          if (hasWebcam && webcamVideo) {
             webcamVideo.currentTime = sourceTimestamp
           }
 


### PR DESCRIPTION
## Description

Had an issue where no video would render (forever stuck at 0%, last log `render:start IPC to renderWorker`) without a webcam present/enabled, the patched code fixed the issue.
