### PR TITLE
fix(export): Resolve hung export process by adding timeout to seekPro…

### DIFF
--- a/src/pages/RendererPage.tsx
+++ b/src/pages/RendererPage.tsx
@@ -185,7 +185,14 @@ export function RendererPage() {
         // --- 5. SETUP SEEK-DRIVEN RENDER LOOP ---
         const seekPromise = (videoElement: HTMLVideoElement) => {
           return new Promise<void>((resolve) => {
+            const timeout = setTimeout(() => {
+              log.warn('[RendererPage] Seek operation timed out.')
+              videoElement.removeEventListener('seeked', onSeeked) // Clean up listener on timeout
+              resolve() // Resolve anyway to not block the loop
+            }, 1000) // 1 second timeout
+
             const onSeeked = () => {
+              clearTimeout(timeout)
               videoElement.removeEventListener('seeked', onSeeked)
               resolve()
             }


### PR DESCRIPTION
…mise

The video export process would hang indefinitely without producing any frames. This was caused by the render loop getting stuck waiting for a 'seeked' event that never fired, particularly for the first frame where currentTime is 0.

## Description

Please provide a clear and concise description of what this Pull Request does.

## Related Issue

Fixes #[issue_number]

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
