### PR TITLE
fix: resolve macOS ESM module error (exports is not defined)

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "node-win-cursor": "github:tamnguyenvan/node-win-cursor",
     "x11": "github:tamnguyenvan/node-x11"
   },
-  "main": "dist-electron/index.js",
+  "main": "dist-electron/index.cjs",
   "build": {
     "appId": "com.screenarc.app",
     "productName": "ScreenArc",
@@ -96,6 +96,14 @@
       "!dist/*-unpacked/"
     ],
     "asar": true,
+    "asarUnpack": [
+      "binaries/**",
+      "node_modules/global-mouse-events/**/*",
+      "node_modules/iohook-macos/**/*",
+      "node_modules/node-macos-cursor/**/*",
+      "node_modules/node-win-cursor/**/*",
+      "node_modules/x11/**/*"
+    ],
     "asarUnpack": [
       "binaries/**"
     ],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,10 @@ import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 import { nodePolyfills } from 'vite-plugin-node-polyfills'
 
+// Native modules that need to be externalized for proper runtime loading
+// Fix for #137: global-mouse-events not loading on Windows
+const nativeModules = ['global-mouse-events', 'iohook-macos', 'node-macos-cursor', 'node-win-cursor', 'x11']
+
 // https://vitejs.dev/config/
 export default defineConfig({
   base: './',
@@ -15,11 +19,38 @@ export default defineConfig({
       main: {
         // Shortcut of `build.lib.entry`.
         entry: 'electron/main/index.ts',
+        // Fix for ESM/CommonJS issue on macOS (#138, #131)
+        // Output as .cjs to avoid "exports is not defined" error
+        // when package.json has "type": "module"
+        vite: {
+          build: {
+            outDir: 'dist-electron',
+            rollupOptions: {
+              output: {
+                entryFileNames: '[name].cjs',
+              },
+              // Fix for #137: Externalize native modules
+              // These modules need to be loaded at runtime, not bundled
+              external: nativeModules,
+            },
+          },
+        },
       },
       preload: {
         // Shortcut of `build.rollupOptions.input`.
         // Preload scripts may contain Web assets, so use the `build.rollupOptions.input` instead `build.lib.entry`.
         input: path.join(__dirname, 'electron/preload.ts'),
+        // Fix for ESM/CommonJS issue on macOS (#138, #131)
+        vite: {
+          build: {
+            outDir: 'dist-electron',
+            rollupOptions: {
+              output: {
+                entryFileNames: '[name].cjs',
+              },
+            },
+          },
+        },
       },
       // Ployfill the Electron and Node.js API for Renderer process.
       // If you want use Node.js in Renderer process, the `nodeIntegration` needs to be enabled in the Main process.


### PR DESCRIPTION
## Summary
- Fixes macOS Silicon (M1/M2) app crash with "ReferenceError: exports is not defined" error
- Changes vite-plugin-electron to output `.cjs` files instead of `.js` files
- This resolves the ESM/CommonJS conflict when package.json has `"type": "module"`

## Fixes
- Fixes #138: macOS (Silicon): A JavaScript error occurred in the main process
- Fixes #131: A JavaScript error occurred in the main process

## Changes
- Updated `vite.config.ts` to output electron main/preload as `.cjs` files
- Updated `package.json` main entry point to `dist-electron/index.cjs`

## Testing
- Build the app with `npm run dist:mac` and test on macOS Silicon