### PR TITLE
fix: resolve Windows display scaling mismatch (fixes #135)

### DIFF
--- a/electron/main/features/recording-manager.ts
+++ b/electron/main/features/recording-manager.ts
@@ -322,6 +322,19 @@ export async function startRecording(options: any) {
   if (source === 'fullscreen') {
     const allDisplays = screen.getAllDisplays()
     const targetDisplay = allDisplays.find((d) => d.id === displayId) || screen.getPrimaryDisplay()
+    // Fix for #135: Use scaleFactor to get physical pixel dimensions
+    // display.bounds returns screen coordinates (scaled), but FFmpeg needs physical pixels
+    const scaleFactor = targetDisplay.scaleFactor
+    const x = Math.round(targetDisplay.bounds.x * scaleFactor)
+    const y = Math.round(targetDisplay.bounds.y * scaleFactor)
+    const width = Math.round(targetDisplay.bounds.width * scaleFactor)
+    const height = Math.round(targetDisplay.bounds.height * scaleFactor)
+    const safeWidth = Math.floor(width / 2) * 2
+    const safeHeight = Math.floor(height / 2) * 2
+    recordingGeometry = { x, y, width: safeWidth, height: safeHeight }
+  if (source === 'fullscreen') {
+    const allDisplays = screen.getAllDisplays()
+    const targetDisplay = allDisplays.find((d) => d.id === displayId) || screen.getPrimaryDisplay()
     const { x, y, width, height } = targetDisplay.bounds
     const safeWidth = Math.floor(width / 2) * 2
     const safeHeight = Math.floor(height / 2) * 2

--- a/electron/main/ipc/handlers/desktop.ts
+++ b/electron/main/ipc/handlers/desktop.ts
@@ -13,6 +13,27 @@ import { CursorTheme } from '../../types'
 
 export function getDisplays() {
   const primaryDisplay = screen.getPrimaryDisplay()
+  return screen.getAllDisplays().map((display, index) => {
+    // Fix for #135: Use scaleFactor to get physical pixel dimensions
+    // display.bounds returns screen coordinates (scaled), but we need physical pixels
+    // for accurate screen capture with FFmpeg
+    const scaleFactor = display.scaleFactor
+    const physicalBounds = {
+      x: Math.round(display.bounds.x * scaleFactor),
+      y: Math.round(display.bounds.y * scaleFactor),
+      width: Math.round(display.bounds.width * scaleFactor),
+      height: Math.round(display.bounds.height * scaleFactor),
+    }
+    return {
+      id: display.id,
+      name: `Display ${index + 1} (${physicalBounds.width}x${physicalBounds.height})`,
+      bounds: physicalBounds,
+      isPrimary: display.id === primaryDisplay.id,
+      scaleFactor,
+    }
+  })
+}
+  const primaryDisplay = screen.getPrimaryDisplay()
   return screen.getAllDisplays().map((display, index) => ({
     id: display.id,
     name: `Display ${index + 1} (${display.bounds.width}x${display.bounds.height})`,


### PR DESCRIPTION
## Summary
- Fixes the issue where fullscreen display size doesn't match Windows OS display size
- Accounts for DPI scaling when calculating display dimensions
- Uses physical pixel dimensions instead of scaled screen coordinates

## Fixes
- Fixes #135: The fullscreen display size does not match the Windows OS display size

## Changes
- Updated `getDisplays()` in `desktop.ts` to multiply bounds by scaleFactor
- Updated `recording-manager.ts` to use physical pixel dimensions for FFmpeg
- Returns both physical bounds and scaleFactor for proper capture

## Root Cause
When Windows has DPI scaling enabled (e.g., 150%), Electron's `display.bounds` returns scaled screen coordinates, not physical pixels. FFmpeg's gdigrab needs physical pixels for accurate capture.

## Testing
- Test on Windows with various DPI scaling settings (100%, 125%, 150%, etc.)
- Verify fullscreen capture matches the OS-reported resolution