### PR TITLE
fix: route microphone audio to screen.mp4 instead of webcam.mp4 (fixes #130)

### DIFF
--- a/electron/main/features/recording-manager.ts
+++ b/electron/main/features/recording-manager.ts
@@ -193,6 +193,57 @@ function buildFfmpegArgs(
     screenOut,
   )
 
+  // Map audio stream if present - must specify output file (screenOut)
+  // Fix for #130: Audio was being routed to webcam file instead of screen file
+  if (hasMic) {
+    finalArgs.push('-map', `${micIndex}:a`, '-c:a', 'aac', '-b:a', '192k', screenOut)
+  }
+
+  // Map webcam video stream if present (video only, no audio)
+  if (hasWebcam && webcamOut) {
+    finalArgs.push(
+      '-map',
+      `${webcamIndex}:v`,
+      '-c:v',
+      'libx264',
+      '-preset',
+      'ultrafast',
+      '-pix_fmt',
+      'yuv420p',
+      webcamOut,
+    )
+  }
+
+  return finalArgs
+}
+ * Constructs the final FFmpeg command arguments by mapping input streams to output files.
+ */
+function buildFfmpegArgs(
+  inputArgs: string[],
+  hasWebcam: boolean,
+  hasMic: boolean,
+  screenOut: string,
+  webcamOut?: string,
+): string[] {
+  const finalArgs = [...inputArgs]
+  // Determine the index of each input stream (mic, webcam, screen)
+  const micIndex = hasMic ? 0 : -1
+  const webcamIndex = hasMic ? (hasWebcam ? 1 : -1) : hasWebcam ? 0 : -1
+  const screenIndex = (hasMic ? 1 : 0) + (hasWebcam ? 1 : 0)
+
+  // Map screen video stream
+  finalArgs.push(
+    '-map',
+    `${screenIndex}:v`,
+    '-c:v',
+    'libx264',
+    '-preset',
+    'ultrafast',
+    '-pix_fmt',
+    'yuv420p',
+    screenOut,
+  )
+
   // Map audio stream if present
   if (hasMic) {
     finalArgs.push('-map', `${micIndex}:a`, '-c:a', 'aac', '-b:a', '192k')


### PR DESCRIPTION
## Summary
- Fixes the issue where microphone audio was being recorded to the webcam video file instead of the screen recording file
- Audio is now routed to the screen output file (screen.mp4) as expected
- Webcam output now contains only video (no audio)

## Fixes
- Fixes #130: No audio being recorded

## Root Cause
The FFmpeg command builder was missing an output file for the audio stream mapping. Without an explicit output file, FFmpeg appended the audio stream to the next output (webcam.mp4), causing the screen recording to have no audio.

## Changes
- Updated `buildFfmpegArgs()` in `recording-manager.ts` to specify `screenOut` as the output file for audio mapping

## Testing
- Record a video with microphone enabled (with or without webcam)
- Verify that the screen recording (screen.mp4) contains both video and audio
- Verify that the webcam recording (webcam.mp4) contains only video