### PR TITLE
fix: improve export progress display to show actual progress (fixes #133)

### DIFF
--- a/src/components/editor/ExportModal.tsx
+++ b/src/components/editor/ExportModal.tsx
@@ -218,7 +218,7 @@ const ProgressView = ({ progress, onCancel }: { progress: number; onCancel: () =
         style={{ width: `${progress}%` }}
       />
     </div>
-    <p className="text-sm font-semibold text-primary mt-4 tabular-nums">{Math.round(progress)}%</p>
+    <p className="text-sm font-semibold text-primary mt-4 tabular-nums">{progress < 0.1 ? '< 1' : Math.round(progress)}%</p>
     <Button variant="secondary" onClick={onCancel} className="mt-8 w-full">
       Cancel
     </Button>


### PR DESCRIPTION
## Summary
- Fixes the issue where export progress showed 0% even while exporting
- Changed display to show '< 1%' when progress is below 0.1%
- Provides better user feedback during export

## Fixes
- Fixes #133: Export Video progress always in 0%

## Root Cause
The progress was displayed using `Math.round(progress)`, which rounds down to 0% for any value less than 0.5%. For a typical 2-minute video at 30fps (3600 frames), the first frame represents only ~0.03% progress, which rounds to 0%.

## Changes
- Updated ExportModal.tsx to show '< 1%' when progress < 0.1%
- This provides immediate feedback that export has started

## Testing
- Start an export and observe the progress display
- Verify it shows '< 1%' initially rather than '0%'