### PR TITLE
fix: remove duplicate code from bad merge

### DIFF
--- a/electron/main/features/recording-manager.ts
+++ b/electron/main/features/recording-manager.ts
@@ -216,57 +216,6 @@ function buildFfmpegArgs(
 
   return finalArgs
 }
- * Constructs the final FFmpeg command arguments by mapping input streams to output files.
- */
-function buildFfmpegArgs(
-  inputArgs: string[],
-  hasWebcam: boolean,
-  hasMic: boolean,
-  screenOut: string,
-  webcamOut?: string,
-): string[] {
-  const finalArgs = [...inputArgs]
-  // Determine the index of each input stream (mic, webcam, screen)
-  const micIndex = hasMic ? 0 : -1
-  const webcamIndex = hasMic ? (hasWebcam ? 1 : -1) : hasWebcam ? 0 : -1
-  const screenIndex = (hasMic ? 1 : 0) + (hasWebcam ? 1 : 0)
-
-  // Map screen video stream
-  finalArgs.push(
-    '-map',
-    `${screenIndex}:v`,
-    '-c:v',
-    'libx264',
-    '-preset',
-    'ultrafast',
-    '-pix_fmt',
-    'yuv420p',
-    screenOut,
-  )
-
-  // Map audio stream if present
-  if (hasMic) {
-    finalArgs.push('-map', `${micIndex}:a`, '-c:a', 'aac', '-b:a', '192k')
-  }
-
-  // Map webcam video stream if present
-  if (hasWebcam && webcamOut) {
-    finalArgs.push(
-      '-map',
-      `${webcamIndex}:v`,
-      '-c:v',
-      'libx264',
-      '-preset',
-      'ultrafast',
-      '-pix_fmt',
-      'yuv420p',
-      webcamOut,
-    )
-  }
-
-  return finalArgs
-}
-
 /**
  * Creates the system tray icon and context menu for controlling an active recording.
  */
@@ -380,13 +329,6 @@ export async function startRecording(options: any) {
     const y = Math.round(targetDisplay.bounds.y * scaleFactor)
     const width = Math.round(targetDisplay.bounds.width * scaleFactor)
     const height = Math.round(targetDisplay.bounds.height * scaleFactor)
-    const safeWidth = Math.floor(width / 2) * 2
-    const safeHeight = Math.floor(height / 2) * 2
-    recordingGeometry = { x, y, width: safeWidth, height: safeHeight }
-  if (source === 'fullscreen') {
-    const allDisplays = screen.getAllDisplays()
-    const targetDisplay = allDisplays.find((d) => d.id === displayId) || screen.getPrimaryDisplay()
-    const { x, y, width, height } = targetDisplay.bounds
     const safeWidth = Math.floor(width / 2) * 2
     const safeHeight = Math.floor(height / 2) * 2
     recordingGeometry = { x, y, width: safeWidth, height: safeHeight }

--- a/electron/main/ipc/handlers/desktop.ts
+++ b/electron/main/ipc/handlers/desktop.ts
@@ -33,14 +33,6 @@ export function getDisplays() {
     }
   })
 }
-  const primaryDisplay = screen.getPrimaryDisplay()
-  return screen.getAllDisplays().map((display, index) => ({
-    id: display.id,
-    name: `Display ${index + 1} (${display.bounds.width}x${display.bounds.height})`,
-    bounds: display.bounds,
-    isPrimary: display.id === primaryDisplay.id,
-  }))
-}
 
 export function handleGetCursorScale() {
   return getCursorScale()

--- a/src/lib/transform.ts
+++ b/src/lib/transform.ts
@@ -186,39 +186,8 @@ export const calculateZoomTransform = (
     currentTranslateX = lerp(0, initialPan.tx, t)
     currentTranslateY = lerp(0, initialPan.ty, t)
   }
-  // let initialPan = { tx: 0, ty: 0 }
-  let livePan = { tx: 0, ty: 0 }
-  let finalPan = { tx: 0, ty: 0 }
-
-  if (mode === 'auto' && metadata.length > 0 && recordingGeometry.width > 0) {
-    // Pan target for the end of the zoom-in transition (STATIONARY)
-    // const initialMousePos = getSmoothedMousePosition(metadata, zoomInEndTime)
-    // initialPan = calculateBoundedPan(initialMousePos, fixedOrigin, zoomLevel, recordingGeometry, frameContentDimensions)
-
-    // Live pan target for the hold phase (DYNAMIC)
-    const liveMousePos = getSmoothedMousePosition(metadata, currentTime)
-    livePan = calculateBoundedPan(liveMousePos, fixedOrigin, zoomLevel, recordingGeometry, frameContentDimensions)
-
-    // Pan target for the start of the zoom-out transition (STATIONARY)
-    const finalMousePos = getSmoothedMousePosition(metadata, zoomOutStartTime)
-    finalPan = calculateBoundedPan(finalMousePos, fixedOrigin, zoomLevel, recordingGeometry, frameContentDimensions)
-  }
-
-  // --- Determine current transform based on phase ---
-
-  // Phase 1: ZOOM-IN (No panning, just move towards initial pan position)
-  if (currentTime >= startTime && currentTime < zoomInEndTime) {
-    console.log('is being zoom-in')
-    const t = (EASING_MAP[easing as keyof typeof EASING_MAP] || EASING_MAP.Balanced)(
-      (currentTime - startTime) / transitionDuration,
-    )
-    currentScale = lerp(1, zoomLevel, t)
-    // currentTranslateX = lerp(0, initialPan.tx, t)
-    // currentTranslateY = lerp(0, initialPan.ty, t)
-  }
   // Phase 2: PAN/HOLD (Fully zoomed in, pan follows smoothed mouse)
   else if (currentTime >= zoomInEndTime && currentTime < zoomOutStartTime) {
-    console.log('is being pan/hold')
     currentScale = zoomLevel
     currentTranslateX = livePan.tx
     currentTranslateY = livePan.ty


### PR DESCRIPTION
## Summary
- Removes duplicate `buildFfmpegArgs` function body in `recording-manager.ts` (broken JSDoc + old copy without #130 audio routing fix)
- Removes duplicate `getDisplays` function body in `desktop.ts` (old copy without #135 scaleFactor fix)
- Removes duplicate pan calculation / phase logic in `transform.ts` (old copy without #132 smooth zoom-in interpolation fix, with leftover `console.log` debug statements)

All three files had the same root cause: merge commit `645881d` (PR #142) introduced duplicate code blocks from improperly resolved merge conflicts, causing TypeScript compilation failure on CI.

Closes #146

## Test plan
- [x] `npm run build` succeeds locally
- [ ] CI build passes on all platforms (Linux, macOS, Windows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)