### PR TITLE
Fix/153

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,9 @@
         "vite-plugin-electron": "^0.28.6",
         "vite-plugin-node-polyfills": "^0.24.0"
       },
+      "engines": {
+        "node": ">=18 <=22"
+      },
       "optionalDependencies": {
         "global-mouse-events": "github:tamnguyenvan/global-mouse-events",
         "iohook-macos": "github:tamnguyenvan/iohook-macos",

--- a/package.json
+++ b/package.json
@@ -91,6 +91,9 @@
   "build": {
     "appId": "com.screenarc.app",
     "productName": "ScreenArc",
+    "extraMetadata": {
+      "type": "commonjs"
+    },
     "files": [
       "dist/**/*",
       "dist-electron/**/*",


### PR DESCRIPTION
## Summary

Fixes the `ReferenceError: exports is not defined in ES module scope` crash that occurs on launch for macOS universal builds (both Intel and Apple Silicon machines hitting different arch slices).

## Root cause

The previous fix (#139) outputs `dist-electron/index.cjs` so the main process is loaded as CommonJS — that part works. The remaining failure comes from `@electron/universal`:

When the x64 and arm64 asars differ, `@electron/universal` generates a CommonJS **stub** `index.js` at the root of `app.asar` that re-routes to the correct arch-specific asar (`app-x64.asar` / `app-arm64.asar`). It then copies the source `package.json` next to the stub and overrides `main: "index.js"` — **but never strips `"type": "module"`**.

Result: Node.js sees `.js` + `type: module` and refuses to load the stub, throwing on `exports`/`require`. The previous `.cjs` fix never gets a chance to run because the stub fails first.

Reference: [`@electron/universal/dist/cjs/index.js#L208-L211`](https://github.com/electron/universal/blob/main/src/index.ts) and the stub at [`entry-asar/has-asar.js`](https://github.com/electron/universal/blob/main/entry-asar/has-asar.js).

## Fix

Use electron-builder's `extraMetadata` to override `type` to `"commonjs"` **only inside the packaged asar's `package.json`**:

```json
"build": {
  "extraMetadata": {
    "type": "commonjs"
  }
}
