### PR TITLE
feat(macos): record system audio into screen recordings

### DIFF
--- a/electron/main/features/build-mux-args.test.ts
+++ b/electron/main/features/build-mux-args.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from 'vitest'
+import { buildMuxArgs } from './build-mux-args'
+
+const SCREEN = '/tmp/screen.mp4'
+const SYS = '/tmp/system.webm'
+const OUT = '/tmp/final.mp4'
+
+describe('buildMuxArgs', () => {
+  test('mic + system: amix two streams, copy video', () => {
+    const args = buildMuxArgs({
+      screenInput: SCREEN,
+      systemAudioInput: SYS,
+      output: OUT,
+      hasMicAudio: true,
+    })
+
+    expect(args).toEqual([
+      '-y',
+      '-i', SCREEN,
+      '-i', SYS,
+      '-filter_complex',
+      '[0:a][1:a]amix=inputs=2:duration=first:dropout_transition=0,aresample=async=1[a]',
+      '-map', '0:v',
+      '-map', '[a]',
+      '-c:v', 'copy',
+      '-c:a', 'aac',
+      '-b:a', '192k',
+      '-shortest',
+      OUT,
+    ])
+  })
+
+  test('system only: passes system audio straight through', () => {
+    const args = buildMuxArgs({
+      screenInput: SCREEN,
+      systemAudioInput: SYS,
+      output: OUT,
+      hasMicAudio: false,
+    })
+
+    expect(args).toEqual([
+      '-y',
+      '-i', SCREEN,
+      '-i', SYS,
+      '-filter_complex',
+      '[1:a]aresample=async=1[a]',
+      '-map', '0:v',
+      '-map', '[a]',
+      '-c:v', 'copy',
+      '-c:a', 'aac',
+      '-b:a', '192k',
+      '-shortest',
+      OUT,
+    ])
+  })
+
+  test('mic only (no system audio): copies streams without filter graph', () => {
+    const args = buildMuxArgs({
+      screenInput: SCREEN,
+      systemAudioInput: undefined,
+      output: OUT,
+      hasMicAudio: true,
+    })
+
+    expect(args).toEqual([
+      '-y',
+      '-i', SCREEN,
+      '-c', 'copy',
+      OUT,
+    ])
+  })
+
+  test('no audio at all: copies streams without filter graph', () => {
+    const args = buildMuxArgs({
+      screenInput: SCREEN,
+      systemAudioInput: undefined,
+      output: OUT,
+      hasMicAudio: false,
+    })
+
+    expect(args).toEqual([
+      '-y',
+      '-i', SCREEN,
+      '-c', 'copy',
+      OUT,
+    ])
+  })
+
+  test('paths with spaces are not pre-quoted (spawn handles them)', () => {
+    const args = buildMuxArgs({
+      screenInput: '/tmp/with space/screen.mp4',
+      systemAudioInput: '/tmp/with space/system.webm',
+      output: '/tmp/with space/out.mp4',
+      hasMicAudio: false,
+    })
+
+    expect(args).toContain('/tmp/with space/screen.mp4')
+    expect(args).toContain('/tmp/with space/system.webm')
+    expect(args).toContain('/tmp/with space/out.mp4')
+    // No bash-style quoting in args
+    args.forEach((a) => expect(a).not.toMatch(/^".*"$/))
+  })
+})

--- a/electron/main/features/build-mux-args.ts
+++ b/electron/main/features/build-mux-args.ts
@@ -1,0 +1,44 @@
+// Builds FFmpeg arguments for the post-recording mux step that combines the
+// screen-capture file with an optional renderer-recorded system-audio WebM.
+//
+// Layout:
+//   input 0: screen capture (mp4) — may already contain mic audio
+//   input 1: system audio (webm/opus) — optional
+//
+// When both mic and system audio are present, they are mixed via amix.
+// When only system audio is present, it is mapped through aresample for
+// drift correction. When neither extra audio applies, we just stream-copy.
+
+export interface BuildMuxArgsOptions {
+  screenInput: string
+  systemAudioInput: string | undefined
+  output: string
+  hasMicAudio: boolean
+}
+
+export function buildMuxArgs(opts: BuildMuxArgsOptions): string[] {
+  const { screenInput, systemAudioInput, output, hasMicAudio } = opts
+
+  // No system audio file: nothing to mux. Stream-copy to a renamed output.
+  if (!systemAudioInput) {
+    return ['-y', '-i', screenInput, '-c', 'copy', output]
+  }
+
+  const filterGraph = hasMicAudio
+    ? '[0:a][1:a]amix=inputs=2:duration=first:dropout_transition=0,aresample=async=1[a]'
+    : '[1:a]aresample=async=1[a]'
+
+  return [
+    '-y',
+    '-i', screenInput,
+    '-i', systemAudioInput,
+    '-filter_complex', filterGraph,
+    '-map', '0:v',
+    '-map', '[a]',
+    '-c:v', 'copy',
+    '-c:a', 'aac',
+    '-b:a', '192k',
+    '-shortest',
+    output,
+  ]
+}

--- a/electron/main/features/recording-manager.ts
+++ b/electron/main/features/recording-manager.ts
@@ -14,8 +14,18 @@ import { getCursorScale, restoreOriginalCursorScale, resetCursorScale } from './
 import { createEditorWindow, cleanupEditorFiles } from '../windows/editor-window'
 import { createSavingWindow, createSelectionWindow } from '../windows/temporary-windows'
 import type { RecordingSession, RecordingGeometry } from '../state'
+import { SystemAudioWriter } from './system-audio-writer'
+import { buildMuxArgs } from './build-mux-args'
 
 const FFMPEG_PATH = getFFmpegPath()
+
+// Module-scoped writer used by the renderer-streamed system-audio capture path.
+// Lives outside appState because it's a helper, not session data.
+const systemAudioWriter = new SystemAudioWriter()
+
+export function getSystemAudioWriter(): SystemAudioWriter {
+  return systemAudioWriter
+}
 
 /**
  * Uses ffprobe to get the precise creation time of the video file.
@@ -76,12 +86,14 @@ async function validateRecordingFiles(session: RecordingSession): Promise<boolea
  * @param inputArgs - Platform-specific FFmpeg input arguments.
  * @param hasWebcam - Flag indicating if webcam recording is enabled.
  * @param hasMic - Flag indicating if microphone recording is enabled.
+ * @param hasSystemAudio - Flag indicating if renderer-side system audio capture is enabled.
  * @param recordingGeometry - The logical dimensions and position of the recording area.
  */
 async function startActualRecording(
   inputArgs: string[],
   hasWebcam: boolean,
   hasMic: boolean,
+  hasSystemAudio: boolean,
   recordingGeometry: RecordingGeometry,
 ) {
   const recordingDir = path.join(process.env.HOME || process.env.USERPROFILE || '.', '.screenarc')
@@ -90,10 +102,23 @@ async function startActualRecording(
 
   const screenVideoPath = path.join(recordingDir, `${baseName}-screen.mp4`)
   const webcamVideoPath = hasWebcam ? path.join(recordingDir, `${baseName}-webcam.mp4`) : undefined
+  const systemAudioPath = hasSystemAudio ? path.join(recordingDir, `${baseName}-system.webm`) : undefined
   const metadataPath = path.join(recordingDir, `${baseName}.json`)
 
   // Store recordingGeometry in the session
-  appState.currentRecordingSession = { screenVideoPath, webcamVideoPath, metadataPath, recordingGeometry }
+  appState.currentRecordingSession = {
+    screenVideoPath,
+    webcamVideoPath,
+    systemAudioPath,
+    hasMicAudio: hasMic,
+    metadataPath,
+    recordingGeometry,
+  }
+
+  if (systemAudioPath) {
+    systemAudioWriter.start(systemAudioPath)
+  }
+
   appState.recorderWin?.minimize()
 
   // Reset state for the new session
@@ -245,8 +270,13 @@ function createTray() {
  * @param options - The recording configuration selected by the user.
  */
 export async function startRecording(options: any) {
-  const { source, displayId, mic, webcam } = options
+  const { source, displayId, mic, webcam, systemAudio } = options
   log.info('[RecordingManager] Received start recording request with options:', options)
+
+  // System audio is currently only supported on macOS (uses ScreenCaptureKit /
+  // CoreAudio Tap via electron-audio-loopback). Silently drop the flag on
+  // other platforms so the rest of the flow stays the same.
+  const wantsSystemAudio = !!systemAudio && process.platform === 'darwin'
 
   // macOS Permissions Check
   if (process.platform === 'darwin') {
@@ -283,6 +313,15 @@ export async function startRecording(options: any) {
         )
         return { canceled: true }
       }
+    }
+
+    // 3. Heads-up for System Audio capture. The actual TCC prompt is fired by
+    // Chromium when the renderer calls getDisplayMedia. We can't pre-flight it
+    // here, but we can inform the user that a prompt will appear on first use.
+    // CoreAudio Tap permission (macOS 14.4+) is a separate prompt from Screen
+    // Recording — it requires NSAudioCaptureUsageDescription in Info.plist.
+    if (wantsSystemAudio) {
+      log.info('[RecordingManager] System audio capture requested — Chromium will prompt for permission on first getDisplayMedia.')
     }
   }
 
@@ -429,7 +468,7 @@ export async function startRecording(options: any) {
     appState.originalCursorScale = await getCursorScale()
   }
   log.info('[RecordingManager] Starting actual recording with args:', baseFfmpegArgs)
-  return startActualRecording(baseFfmpegArgs, !!webcam, !!mic, recordingGeometry)
+  return startActualRecording(baseFfmpegArgs, !!webcam, !!mic, wantsSystemAudio, recordingGeometry)
 }
 
 /**
@@ -442,9 +481,18 @@ export async function stopRecording() {
   appState.tray = null
   createSavingWindow()
 
+  // Tell the renderer to stop its MediaRecorder so any pending chunks land in
+  // the writer's queue. The recorder window flushes a final chunk on stop().
+  appState.recorderWin?.webContents.send('recorder:stop-system-audio')
+
   // Step 1: Wait for FFmpeg and tracker to finish
   await cleanupAndSave()
   log.info('FFmpeg process finished and file is finalized.')
+
+  // Step 1b: Flush and finalize the system-audio file (no-op when not used).
+  // This must come AFTER cleanupAndSave so any final chunks the renderer
+  // emitted in response to 'recorder:stop-system-audio' have time to arrive.
+  await systemAudioWriter.finalize()
 
   const session = appState.currentRecordingSession
   if (!session) {
@@ -459,6 +507,18 @@ export async function stopRecording() {
 
   // Step 2: Process and save metadata (after video file is complete)
   await processAndSaveMetadata(session)
+
+  // Step 2b: If we captured system audio, mux it into the screen file.
+  if (session.systemAudioPath) {
+    try {
+      await muxSystemAudio(session)
+    } catch (err) {
+      log.error('[StopRecord] Failed to mux system audio. Keeping original screen file.', err)
+      // Non-fatal: leave the original screen file intact and discard the system file.
+      await fsPromises.unlink(session.systemAudioPath).catch(() => {})
+      session.systemAudioPath = undefined
+    }
+  }
 
   // Step 3: Validate file
   const isValid = await validateRecordingFiles(session)
@@ -486,6 +546,61 @@ export async function stopRecording() {
     )
   }
   appState.recorderWin?.close()
+}
+
+/**
+ * Muxes the renderer-recorded system-audio WebM into the screen file. Replaces
+ * `session.screenVideoPath` in place; deletes the system-audio temp file.
+ */
+async function muxSystemAudio(session: RecordingSession): Promise<void> {
+  if (!session.systemAudioPath) return
+
+  // Validate inputs exist and have content. A zero-byte system-audio file
+  // means the renderer never delivered chunks (e.g., permission denied) —
+  // skip the mux and proceed with the original screen file.
+  try {
+    const sysStat = await fsPromises.stat(session.systemAudioPath)
+    if (sysStat.size === 0) {
+      log.warn('[Mux] System audio file is empty; skipping mux.')
+      await fsPromises.unlink(session.systemAudioPath).catch(() => {})
+      session.systemAudioPath = undefined
+      return
+    }
+  } catch (err) {
+    log.warn('[Mux] System audio file missing; skipping mux.', err)
+    session.systemAudioPath = undefined
+    return
+  }
+
+  const tempOutput = session.screenVideoPath.replace(/\.mp4$/, '.muxed.mp4')
+  const args = buildMuxArgs({
+    screenInput: session.screenVideoPath,
+    systemAudioInput: session.systemAudioPath,
+    output: tempOutput,
+    hasMicAudio: !!session.hasMicAudio,
+  })
+
+  log.info(`[Mux] Running ffmpeg ${args.join(' ')}`)
+
+  await new Promise<void>((resolve, reject) => {
+    const proc = spawn(FFMPEG_PATH, args)
+    let stderr = ''
+    proc.stderr.on('data', (d) => {
+      stderr += d.toString()
+    })
+    proc.on('error', reject)
+    proc.on('close', (code) => {
+      if (code === 0) resolve()
+      else reject(new Error(`ffmpeg mux exited ${code}: ${stderr.slice(-500)}`))
+    })
+  })
+
+  // Atomic-ish swap: rename muxed → screen, drop the original screen by virtue
+  // of the rename overwriting it. Then drop the system-audio temp file.
+  await fsPromises.rename(tempOutput, session.screenVideoPath)
+  await fsPromises.unlink(session.systemAudioPath).catch(() => {})
+  session.systemAudioPath = undefined
+  log.info('[Mux] System audio successfully muxed into screen file.')
 }
 
 /**
@@ -584,6 +699,11 @@ export async function cleanupAndDiscard() {
   appState.ffmpegProcess?.kill('SIGKILL')
   appState.ffmpegProcess = null
 
+  // Tell the renderer to stop its MediaRecorder; even if it ignores us,
+  // aborting the writer means subsequent IPC chunks are no-ops.
+  appState.recorderWin?.webContents.send('recorder:stop-system-audio')
+  await systemAudioWriter.abort()
+
   appState.mouseTracker?.stop()
   appState.mouseTracker = null
 
@@ -597,6 +717,9 @@ export async function cleanupAndDiscard() {
   // Asynchronously delete files to not block the UI
   setTimeout(async () => {
     await cleanupEditorFiles(sessionToDiscard)
+    if (sessionToDiscard.systemAudioPath) {
+      await fsPromises.unlink(sessionToDiscard.systemAudioPath).catch(() => {})
+    }
   }, 200)
 }
 
@@ -618,7 +741,7 @@ export async function cleanupOrphanedRecordings() {
 
   try {
     const allFiles = await fsPromises.readdir(recordingDir)
-    const filePattern = /^ScreenArc-recording-\d+(-screen\.mp4|-webcam\.mp4|\.json)$/
+    const filePattern = /^ScreenArc-recording-\d+(-screen\.mp4|-screen\.muxed\.mp4|-webcam\.mp4|-system\.webm|\.json)$/
     const filesToDelete = allFiles
       .filter((file) => filePattern.test(file))
       .map((file) => path.join(recordingDir, file))

--- a/electron/main/features/recording-manager.ts
+++ b/electron/main/features/recording-manager.ts
@@ -18,13 +18,58 @@ import { SystemAudioWriter } from './system-audio-writer'
 import { buildMuxArgs } from './build-mux-args'
 
 const FFMPEG_PATH = getFFmpegPath()
+const SYSTEM_AUDIO_STOP_TIMEOUT_MS = 5000
 
 // Module-scoped writer used by the renderer-streamed system-audio capture path.
 // Lives outside appState because it's a helper, not session data.
 const systemAudioWriter = new SystemAudioWriter()
+let pendingSystemAudioStop:
+  | {
+      promise: Promise<void>
+      resolve: () => void
+    }
+  | null = null
 
 export function getSystemAudioWriter(): SystemAudioWriter {
   return systemAudioWriter
+}
+
+export function markSystemAudioStopped(): void {
+  pendingSystemAudioStop?.resolve()
+  pendingSystemAudioStop = null
+}
+
+function createSystemAudioStopWaiter(): Promise<void> {
+  if (!pendingSystemAudioStop) {
+    let resolve!: () => void
+    pendingSystemAudioStop = {
+      promise: new Promise<void>((res) => {
+        resolve = res
+      }),
+      resolve,
+    }
+  }
+
+  return pendingSystemAudioStop.promise
+}
+
+async function waitForSystemAudioStop(waiter: Promise<void>): Promise<void> {
+  let didAcknowledge = false
+  try {
+    await Promise.race([
+      waiter.then(() => {
+        didAcknowledge = true
+      }),
+      new Promise<void>((resolve) => {
+        setTimeout(resolve, SYSTEM_AUDIO_STOP_TIMEOUT_MS)
+      }),
+    ])
+  } finally {
+    if (!didAcknowledge) {
+      log.warn('[SystemAudio] Renderer did not acknowledge stop before timeout; finalizing writer anyway.')
+    }
+    pendingSystemAudioStop = null
+  }
 }
 
 /**
@@ -40,6 +85,31 @@ async function getVideoStartTime(videoPath: string): Promise<number> {
     log.error(`[getVideoStartTime] Error getting file stats for ${videoPath}:`, error)
     throw error
   }
+}
+
+async function screenFileHasAudioStream(screenVideoPath: string): Promise<boolean> {
+  return new Promise<boolean>((resolve, reject) => {
+    const proc = spawn(FFMPEG_PATH, ['-v', 'error', '-i', screenVideoPath, '-map', '0:a:0', '-f', 'null', '-'])
+    let stderr = ''
+
+    proc.stderr.on('data', (data) => {
+      stderr += data.toString()
+    })
+    proc.on('error', reject)
+    proc.on('close', (code) => {
+      if (code === 0) {
+        resolve(true)
+        return
+      }
+
+      if (stderr.includes('matches no streams')) {
+        resolve(false)
+        return
+      }
+
+      reject(new Error(`Failed to inspect screen audio stream: ${stderr.slice(-500)}`))
+    })
+  })
 }
 
 /**
@@ -116,6 +186,7 @@ async function startActualRecording(
   }
 
   if (systemAudioPath) {
+    markSystemAudioStopped()
     systemAudioWriter.start(systemAudioPath)
   }
 
@@ -481,21 +552,28 @@ export async function stopRecording() {
   appState.tray = null
   createSavingWindow()
 
+  const session = appState.currentRecordingSession
+  const waitForRendererSystemAudioStop = session?.systemAudioPath ? createSystemAudioStopWaiter() : null
+
   // Tell the renderer to stop its MediaRecorder so any pending chunks land in
   // the writer's queue. The recorder window flushes a final chunk on stop().
-  appState.recorderWin?.webContents.send('recorder:stop-system-audio')
+  if (waitForRendererSystemAudioStop) {
+    appState.recorderWin?.webContents.send('recorder:stop-system-audio')
+  }
 
   // Step 1: Wait for FFmpeg and tracker to finish
   await cleanupAndSave()
   log.info('FFmpeg process finished and file is finalized.')
 
-  // Step 1b: Flush and finalize the system-audio file (no-op when not used).
-  // This must come AFTER cleanupAndSave so any final chunks the renderer
-  // emitted in response to 'recorder:stop-system-audio' have time to arrive.
+  // Step 1b: Wait for the renderer to finish forwarding the tail chunk, then
+  // flush and finalize the system-audio file (no-op when not used).
+  if (waitForRendererSystemAudioStop) {
+    await waitForSystemAudioStop(waitForRendererSystemAudioStop)
+  }
   await systemAudioWriter.finalize()
 
-  const session = appState.currentRecordingSession
-  if (!session) {
+  const finalizedSession = appState.currentRecordingSession
+  if (!finalizedSession) {
     log.error('[StopRecord] No recording session found after cleanup. Aborting.')
     appState.savingWin?.close()
     appState.recorderWin?.show()
@@ -503,28 +581,28 @@ export async function stopRecording() {
   }
 
   // Notify recorder window that the recording has finished, allowing it to reset its UI
-  appState.recorderWin?.webContents.send('recording-finished', { canceled: false, ...session })
+  appState.recorderWin?.webContents.send('recording-finished', { canceled: false, ...finalizedSession })
 
   // Step 2: Process and save metadata (after video file is complete)
-  await processAndSaveMetadata(session)
+  await processAndSaveMetadata(finalizedSession)
 
   // Step 2b: If we captured system audio, mux it into the screen file.
-  if (session.systemAudioPath) {
+  if (finalizedSession.systemAudioPath) {
     try {
-      await muxSystemAudio(session)
+      await muxSystemAudio(finalizedSession)
     } catch (err) {
       log.error('[StopRecord] Failed to mux system audio. Keeping original screen file.', err)
       // Non-fatal: leave the original screen file intact and discard the system file.
-      await fsPromises.unlink(session.systemAudioPath).catch(() => {})
-      session.systemAudioPath = undefined
+      await fsPromises.unlink(finalizedSession.systemAudioPath).catch(() => {})
+      finalizedSession.systemAudioPath = undefined
     }
   }
 
   // Step 3: Validate file
-  const isValid = await validateRecordingFiles(session)
+  const isValid = await validateRecordingFiles(finalizedSession)
   if (!isValid) {
     log.error('[StopRecord] Recording validation failed. Discarding files.')
-    await cleanupEditorFiles(session)
+    await cleanupEditorFiles(finalizedSession)
     appState.currentRecordingSession = null
     appState.savingWin?.close()
     resetCursorScale()
@@ -537,12 +615,12 @@ export async function stopRecording() {
   resetCursorScale()
 
   appState.currentRecordingSession = null
-  if (session) {
+  if (finalizedSession) {
     createEditorWindow(
-      session.screenVideoPath,
-      session.metadataPath,
-      session.recordingGeometry,
-      session.webcamVideoPath,
+      finalizedSession.screenVideoPath,
+      finalizedSession.metadataPath,
+      finalizedSession.recordingGeometry,
+      finalizedSession.webcamVideoPath,
     )
   }
   appState.recorderWin?.close()
@@ -572,33 +650,41 @@ async function muxSystemAudio(session: RecordingSession): Promise<void> {
     return
   }
 
+  const screenHasAudio = session.hasMicAudio ? await screenFileHasAudioStream(session.screenVideoPath) : false
   const tempOutput = session.screenVideoPath.replace(/\.mp4$/, '.muxed.mp4')
   const args = buildMuxArgs({
     screenInput: session.screenVideoPath,
     systemAudioInput: session.systemAudioPath,
     output: tempOutput,
-    hasMicAudio: !!session.hasMicAudio,
+    hasMicAudio: screenHasAudio,
   })
 
   log.info(`[Mux] Running ffmpeg ${args.join(' ')}`)
 
-  await new Promise<void>((resolve, reject) => {
-    const proc = spawn(FFMPEG_PATH, args)
-    let stderr = ''
-    proc.stderr.on('data', (d) => {
-      stderr += d.toString()
+  try {
+    await new Promise<void>((resolve, reject) => {
+      const proc = spawn(FFMPEG_PATH, args)
+      let stderr = ''
+      proc.stderr.on('data', (d) => {
+        stderr += d.toString()
+      })
+      proc.on('error', reject)
+      proc.on('close', (code) => {
+        if (code === 0) resolve()
+        else reject(new Error(`ffmpeg mux exited ${code}: ${stderr.slice(-500)}`))
+      })
     })
-    proc.on('error', reject)
-    proc.on('close', (code) => {
-      if (code === 0) resolve()
-      else reject(new Error(`ffmpeg mux exited ${code}: ${stderr.slice(-500)}`))
-    })
-  })
+  } catch (error) {
+    await fsPromises.unlink(tempOutput).catch(() => {})
+    throw error
+  }
 
   // Atomic-ish swap: rename muxed → screen, drop the original screen by virtue
   // of the rename overwriting it. Then drop the system-audio temp file.
   await fsPromises.rename(tempOutput, session.screenVideoPath)
-  await fsPromises.unlink(session.systemAudioPath).catch(() => {})
+  await fsPromises.unlink(session.systemAudioPath).catch((error) => {
+    log.warn('[Mux] Failed to delete temporary system audio file after mux.', error)
+  })
   session.systemAudioPath = undefined
   log.info('[Mux] System audio successfully muxed into screen file.')
 }
@@ -693,6 +779,7 @@ async function processAndSaveMetadata(session: RecordingSession): Promise<boolea
 export async function cleanupAndDiscard() {
   if (!appState.currentRecordingSession) return
   log.warn('[Cleanup] Discarding current recording session.')
+  markSystemAudioStopped()
   const sessionToDiscard = { ...appState.currentRecordingSession }
   appState.currentRecordingSession = null
 

--- a/electron/main/features/system-audio-writer.test.ts
+++ b/electron/main/features/system-audio-writer.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+
+import { SystemAudioWriter } from './system-audio-writer'
+
+let scratchDir: string
+
+beforeEach(() => {
+  scratchDir = mkdtempSync(path.join(tmpdir(), 'screenarc-saw-'))
+})
+
+afterEach(() => {
+  rmSync(scratchDir, { recursive: true, force: true })
+})
+
+const filePath = () => path.join(scratchDir, 'system.webm')
+
+describe('SystemAudioWriter', () => {
+  test('write() before start() is a safe no-op and reports zero bytes', async () => {
+    const writer = new SystemAudioWriter()
+    const total = await writer.write(Buffer.from([1, 2, 3]))
+    expect(total).toBe(0)
+  })
+
+  test('start() then write() persists bytes to disk and returns running total', async () => {
+    const writer = new SystemAudioWriter()
+    writer.start(filePath())
+
+    const first = await writer.write(Buffer.from([1, 2, 3]))
+    const second = await writer.write(Buffer.from([4, 5]))
+
+    expect(first).toBe(3)
+    expect(second).toBe(5)
+
+    await writer.finalize()
+    const onDisk = readFileSync(filePath())
+    expect(Array.from(onDisk)).toEqual([1, 2, 3, 4, 5])
+  })
+
+  test('concurrent writes are serialized in submission order', async () => {
+    const writer = new SystemAudioWriter()
+    writer.start(filePath())
+
+    // Submit five writes without awaiting between them
+    const writes = [
+      writer.write(Buffer.from([0xa])),
+      writer.write(Buffer.from([0xb])),
+      writer.write(Buffer.from([0xc])),
+      writer.write(Buffer.from([0xd])),
+      writer.write(Buffer.from([0xe])),
+    ]
+
+    const totals = await Promise.all(writes)
+    expect(totals).toEqual([1, 2, 3, 4, 5])
+
+    await writer.finalize()
+    const onDisk = readFileSync(filePath())
+    expect(Array.from(onDisk)).toEqual([0xa, 0xb, 0xc, 0xd, 0xe])
+  })
+
+  test('finalize() flushes pending writes before resolving', async () => {
+    const writer = new SystemAudioWriter()
+    writer.start(filePath())
+
+    writer.write(Buffer.from([1, 2]))
+    writer.write(Buffer.from([3, 4]))
+    await writer.finalize()
+
+    const onDisk = readFileSync(filePath())
+    expect(Array.from(onDisk)).toEqual([1, 2, 3, 4])
+  })
+
+  test('write() after finalize() is a safe no-op', async () => {
+    const writer = new SystemAudioWriter()
+    writer.start(filePath())
+    await writer.write(Buffer.from([1]))
+    await writer.finalize()
+
+    const total = await writer.write(Buffer.from([2, 3]))
+    expect(total).toBe(1)
+
+    const onDisk = readFileSync(filePath())
+    expect(Array.from(onDisk)).toEqual([1])
+  })
+
+  test('abort() prevents further writes from persisting', async () => {
+    const writer = new SystemAudioWriter()
+    writer.start(filePath())
+    const beforeAbort = await writer.write(Buffer.from([1, 2]))
+    await writer.abort()
+
+    const afterAbort = await writer.write(Buffer.from([3, 4]))
+    // Bytes counter does not grow after abort; running total stays at the
+    // last persisted write. The on-disk file may be partial or empty.
+    expect(beforeAbort).toBe(2)
+    expect(afterAbort).toBe(2)
+  })
+
+  test('start() can begin a fresh session after finalize()', async () => {
+    const writer = new SystemAudioWriter()
+    const firstPath = path.join(scratchDir, 'a.webm')
+    const secondPath = path.join(scratchDir, 'b.webm')
+
+    writer.start(firstPath)
+    await writer.write(Buffer.from([0x1, 0x2]))
+    await writer.finalize()
+
+    writer.start(secondPath)
+    const total = await writer.write(Buffer.from([0x9]))
+    await writer.finalize()
+
+    expect(total).toBe(1)
+    expect(Array.from(readFileSync(firstPath))).toEqual([1, 2])
+    expect(Array.from(readFileSync(secondPath))).toEqual([0x9])
+  })
+
+  test('start() creates parent directory if missing', async () => {
+    const writer = new SystemAudioWriter()
+    const nested = path.join(scratchDir, 'nested', 'deep', 'system.webm')
+
+    writer.start(nested)
+    await writer.write(Buffer.from([7]))
+    await writer.finalize()
+
+    expect(Array.from(readFileSync(nested))).toEqual([7])
+  })
+})

--- a/electron/main/features/system-audio-writer.test.ts
+++ b/electron/main/features/system-audio-writer.test.ts
@@ -11,7 +11,8 @@ beforeEach(() => {
   scratchDir = mkdtempSync(path.join(tmpdir(), 'screenarc-saw-'))
 })
 
-afterEach(() => {
+afterEach(async () => {
+  await new Promise((resolve) => setTimeout(resolve, 0))
   rmSync(scratchDir, { recursive: true, force: true })
 })
 
@@ -125,5 +126,25 @@ describe('SystemAudioWriter', () => {
     await writer.finalize()
 
     expect(Array.from(readFileSync(nested))).toEqual([7])
+  })
+
+  test('finalize() rejects after a stream error instead of silently succeeding', async () => {
+    const writer = new SystemAudioWriter()
+    writer.start(filePath())
+
+    ;(writer as unknown as { failure: Error }).failure = new Error('disk full')
+
+    await expect(writer.finalize()).rejects.toThrow('disk full')
+    await expect(writer.write(Buffer.from([1]))).rejects.toThrow('disk full')
+    await writer.abort()
+  })
+
+  test('start() rejects when a previous session is still active', async () => {
+    const writer = new SystemAudioWriter()
+    writer.start(filePath())
+
+    expect(() => writer.start(path.join(scratchDir, 'other.webm'))).toThrow('still active')
+
+    await writer.abort()
   })
 })

--- a/electron/main/features/system-audio-writer.ts
+++ b/electron/main/features/system-audio-writer.ts
@@ -5,56 +5,84 @@
 import log from 'electron-log/main'
 import { createWriteStream, mkdirSync, type WriteStream } from 'node:fs'
 import path from 'node:path'
+import { finished } from 'node:stream/promises'
 
 export class SystemAudioWriter {
   private stream: WriteStream | null = null
   private queue: Promise<void> = Promise.resolve()
   private bytes = 0
   private ended = false
+  private failure: Error | null = null
+  private detachStreamErrorListener: (() => void) | null = null
 
   start(filePath: string): void {
+    if (this.stream) {
+      throw new Error('SystemAudioWriter.start() called while a previous session is still active')
+    }
+
     mkdirSync(path.dirname(filePath), { recursive: true })
 
-    this.stream = createWriteStream(filePath, { flags: 'w' })
+    const stream = createWriteStream(filePath, { flags: 'w' })
+    const onError = (err: Error) => {
+      if (!this.failure) {
+        this.failure = err
+        log.error('[SystemAudioWriter] Stream error:', err)
+      }
+    }
+    stream.on('error', onError)
+
+    this.stream = stream
+    this.detachStreamErrorListener = () => {
+      stream.off('error', onError)
+    }
     this.queue = Promise.resolve()
     this.bytes = 0
     this.ended = false
+    this.failure = null
   }
 
   async write(chunk: Buffer): Promise<number> {
+    if (this.failure) {
+      throw this.failure
+    }
+
     const stream = this.stream
-    if (!stream || this.ended || stream.writableEnded) {
+    if (!stream || this.ended || stream.writableEnded || stream.destroyed) {
       return this.bytes
     }
 
-    this.queue = this.queue
-      .catch(() => {
-        // Swallow earlier errors so subsequent chunks still attempt to flush.
-      })
-      .then(
-        () =>
-          new Promise<void>((resolve, reject) => {
-            if (!this.stream || this.stream.writableEnded) {
-              resolve()
+    const writeTask = this.queue.then(
+      () =>
+        new Promise<void>((resolve, reject) => {
+          if (this.failure) {
+            reject(this.failure)
+            return
+          }
+
+          if (!this.stream || this.stream !== stream || this.stream.writableEnded || this.stream.destroyed) {
+            resolve()
+            return
+          }
+
+          this.stream.write(chunk, (err) => {
+            if (err) {
+              const writeError = err instanceof Error ? err : new Error(String(err))
+              if (!this.failure) {
+                this.failure = writeError
+                log.error('[SystemAudioWriter] Write error:', writeError)
+              }
+              reject(writeError)
               return
             }
-            this.stream.write(chunk, (err) => {
-              if (err) {
-                log.error('[SystemAudioWriter] Write error:', err)
-                reject(err)
-                return
-              }
-              this.bytes += chunk.length
-              resolve()
-            })
-          }),
-      )
 
-    try {
-      await this.queue
-    } catch {
-      // Errors are logged above; the writer remains in a consistent state.
-    }
+            this.bytes += chunk.length
+            resolve()
+          })
+        }),
+    )
+
+    this.queue = writeTask
+    await writeTask
     return this.bytes
   }
 
@@ -64,12 +92,23 @@ export class SystemAudioWriter {
 
     this.ended = true
     try {
-      await this.queue.catch(() => {})
-      if (!stream.writableEnded) {
-        await new Promise<void>((resolve) => stream.end(() => resolve()))
+      await this.queue
+      if (this.failure) {
+        throw this.failure
       }
+
+      if (!stream.writableEnded && !stream.destroyed) {
+        stream.end()
+        await finished(stream)
+      }
+    } catch (error) {
+      if (!stream.destroyed) {
+        stream.destroy()
+        await finished(stream).catch(() => {})
+      }
+      throw error
     } finally {
-      this.stream = null
+      this.reset()
     }
   }
 
@@ -82,7 +121,13 @@ export class SystemAudioWriter {
       stream.destroy()
       await this.queue.catch(() => {})
     } finally {
-      this.stream = null
+      this.reset()
     }
+  }
+
+  private reset(): void {
+    this.detachStreamErrorListener?.()
+    this.detachStreamErrorListener = null
+    this.stream = null
   }
 }

--- a/electron/main/features/system-audio-writer.ts
+++ b/electron/main/features/system-audio-writer.ts
@@ -1,0 +1,88 @@
+// Streams system-audio chunks (WebM/Opus) from the renderer to a file on disk.
+// Append writes are serialized via a promise queue so concurrent IPC chunks
+// never interleave inside the WebM container.
+
+import log from 'electron-log/main'
+import { createWriteStream, mkdirSync, type WriteStream } from 'node:fs'
+import path from 'node:path'
+
+export class SystemAudioWriter {
+  private stream: WriteStream | null = null
+  private queue: Promise<void> = Promise.resolve()
+  private bytes = 0
+  private ended = false
+
+  start(filePath: string): void {
+    mkdirSync(path.dirname(filePath), { recursive: true })
+
+    this.stream = createWriteStream(filePath, { flags: 'w' })
+    this.queue = Promise.resolve()
+    this.bytes = 0
+    this.ended = false
+  }
+
+  async write(chunk: Buffer): Promise<number> {
+    const stream = this.stream
+    if (!stream || this.ended || stream.writableEnded) {
+      return this.bytes
+    }
+
+    this.queue = this.queue
+      .catch(() => {
+        // Swallow earlier errors so subsequent chunks still attempt to flush.
+      })
+      .then(
+        () =>
+          new Promise<void>((resolve, reject) => {
+            if (!this.stream || this.stream.writableEnded) {
+              resolve()
+              return
+            }
+            this.stream.write(chunk, (err) => {
+              if (err) {
+                log.error('[SystemAudioWriter] Write error:', err)
+                reject(err)
+                return
+              }
+              this.bytes += chunk.length
+              resolve()
+            })
+          }),
+      )
+
+    try {
+      await this.queue
+    } catch {
+      // Errors are logged above; the writer remains in a consistent state.
+    }
+    return this.bytes
+  }
+
+  async finalize(): Promise<void> {
+    const stream = this.stream
+    if (!stream) return
+
+    this.ended = true
+    try {
+      await this.queue.catch(() => {})
+      if (!stream.writableEnded) {
+        await new Promise<void>((resolve) => stream.end(() => resolve()))
+      }
+    } finally {
+      this.stream = null
+    }
+  }
+
+  async abort(): Promise<void> {
+    const stream = this.stream
+    if (!stream) return
+
+    this.ended = true
+    try {
+      stream.destroy()
+      await this.queue.catch(() => {})
+    } finally {
+      this.stream = null
+    }
+  }
+}

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -1,6 +1,7 @@
 // Entry point of the Electron application.
 
 import { app, BrowserWindow, protocol, ProtocolRequest, ProtocolResponse, Menu, screen, dialog } from 'electron'
+import { initMain as initAudioLoopback } from 'electron-audio-loopback'
 import log from 'electron-log/main'
 import path from 'node:path'
 import fsSync from 'node:fs'
@@ -14,6 +15,12 @@ import { appState } from './state'
 
 // --- Initialization ---
 setupLogging()
+
+// Enable system audio loopback capture on macOS (12.3+ via ScreenCaptureKit,
+// 14.4+ via CoreAudio Taps with `forceCoreAudioTap: true`). Must run before
+// `app.whenReady()` because it appends Chromium feature flags.
+// See: https://github.com/alectrocute/electron-audio-loopback
+initAudioLoopback({ forceCoreAudioTap: true })
 
 // --- App Lifecycle Events ---
 app.on('window-all-closed', () => {

--- a/electron/main/ipc/handlers/recording.ts
+++ b/electron/main/ipc/handlers/recording.ts
@@ -1,6 +1,12 @@
 // Handlers for recording-related IPC (recording).
 
-import { startRecording, loadVideoFromFile, stopRecording, getSystemAudioWriter } from '../../features/recording-manager'
+import {
+  startRecording,
+  loadVideoFromFile,
+  stopRecording,
+  getSystemAudioWriter,
+  markSystemAudioStopped,
+} from '../../features/recording-manager'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function handleStartRecording(_event: any, options: any) {
@@ -25,4 +31,8 @@ export async function handleWriteSystemAudioChunk(_event: unknown, chunk: ArrayB
     throw new Error('writeSystemAudioChunk: payload must be an ArrayBuffer')
   }
   return getSystemAudioWriter().write(Buffer.from(chunk))
+}
+
+export function handleSystemAudioStopped(): void {
+  markSystemAudioStopped()
 }

--- a/electron/main/ipc/handlers/recording.ts
+++ b/electron/main/ipc/handlers/recording.ts
@@ -1,6 +1,6 @@
 // Handlers for recording-related IPC (recording).
 
-import { startRecording, loadVideoFromFile, stopRecording } from '../../features/recording-manager'
+import { startRecording, loadVideoFromFile, stopRecording, getSystemAudioWriter } from '../../features/recording-manager'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function handleStartRecording(_event: any, options: any) {
@@ -13,4 +13,16 @@ export function handleLoadVideoFromFile() {
 
 export async function handleStopRecording() {
   await stopRecording()
+}
+
+/**
+ * Receives a chunk of system-audio data (WebM cluster) from the renderer's
+ * MediaRecorder and appends it to the on-disk file. Idempotent across
+ * stop/abort: if no active session, the writer silently no-ops.
+ */
+export async function handleWriteSystemAudioChunk(_event: unknown, chunk: ArrayBuffer): Promise<number> {
+  if (!(chunk instanceof ArrayBuffer)) {
+    throw new Error('writeSystemAudioChunk: payload must be an ArrayBuffer')
+  }
+  return getSystemAudioWriter().write(Buffer.from(chunk))
 }

--- a/electron/main/ipc/index.ts
+++ b/electron/main/ipc/index.ts
@@ -35,6 +35,7 @@ export function registerIpcHandlers() {
   ipcMain.on('recording:stop', recordingHandlers.handleStopRecording)
   ipcMain.handle('recording:load-from-file', recordingHandlers.handleLoadVideoFromFile)
   ipcMain.handle('recording:write-system-audio', recordingHandlers.handleWriteSystemAudioChunk)
+  ipcMain.handle('recording:system-audio-stopped', recordingHandlers.handleSystemAudioStopped)
 
   // Export
   ipcMain.handle('export:start', exportHandlers.handleStartExport)

--- a/electron/main/ipc/index.ts
+++ b/electron/main/ipc/index.ts
@@ -34,6 +34,7 @@ export function registerIpcHandlers() {
   ipcMain.handle('recording:start', recordingHandlers.handleStartRecording)
   ipcMain.on('recording:stop', recordingHandlers.handleStopRecording)
   ipcMain.handle('recording:load-from-file', recordingHandlers.handleLoadVideoFromFile)
+  ipcMain.handle('recording:write-system-audio', recordingHandlers.handleWriteSystemAudioChunk)
 
   // Export
   ipcMain.handle('export:start', exportHandlers.handleStartExport)

--- a/electron/main/state.ts
+++ b/electron/main/state.ts
@@ -17,6 +17,11 @@ export interface RecordingSession {
   screenVideoPath: string
   metadataPath: string
   webcamVideoPath?: string
+  // Set when system-audio capture (renderer-side MediaRecorder) is enabled.
+  // Cleared after the post-recording mux merges it into the screen file.
+  systemAudioPath?: string
+  // True when mic capture is enabled for this session. Drives mux filter graph.
+  hasMicAudio?: boolean
   recordingGeometry: RecordingGeometry
 }
 

--- a/electron/main/windows/editor-window.ts
+++ b/electron/main/windows/editor-window.ts
@@ -130,9 +130,10 @@ export async function cleanupEditorFiles(files: {
   screenVideoPath: string
   metadataPath: string
   webcamVideoPath?: string
+  systemAudioPath?: string
 }) {
   log.info('[EditorWindow] Cleaning up session files:', files)
-  const unlinkPromises = [files.screenVideoPath, files.webcamVideoPath, files.metadataPath]
+  const unlinkPromises = [files.screenVideoPath, files.webcamVideoPath, files.metadataPath, files.systemAudioPath]
     .filter(Boolean)
     .map((filePath) => (fsSync.existsSync(filePath!) ? fs.unlink(filePath!) : Promise.resolve()))
   try {

--- a/electron/main/windows/recorder-window.ts
+++ b/electron/main/windows/recorder-window.ts
@@ -29,6 +29,10 @@ export function createRecorderWindow() {
     webPreferences: {
       nodeIntegration: true,
       preload: PRELOAD_SCRIPT,
+      // The recorder window is minimized while a recording is in progress.
+      // Without this, macOS throttles renderer JS and the system-audio
+      // MediaRecorder underruns, dropping audio chunks.
+      backgroundThrottling: false,
     },
   })
 

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -83,11 +83,27 @@ export const electronAPI = {
     displayId?: number
     webcam?: { deviceId: string; deviceLabel: string; index: number }
     mic?: { deviceId: string; deviceLabel: string; index: number }
+    systemAudio?: boolean
   }): Promise<RecordingResult> => ipcRenderer.invoke('recording:start', options),
   stopRecording: (): void => ipcRenderer.send('recording:stop'),
   loadVideoFromFile: (): Promise<RecordingResult> => ipcRenderer.invoke('recording:load-from-file'),
   getCursorScale: (): Promise<number> => ipcRenderer.invoke('desktop:get-cursor-scale'),
   setCursorScale: (scale: number): void => ipcRenderer.send('desktop:set-cursor-scale', scale),
+
+  // --- System Audio Loopback (macOS) ---
+  // electron-audio-loopback registers `enable-loopback-audio` and
+  // `disable-loopback-audio` IPC handlers in initMain(). Wrap each
+  // getDisplayMedia call between enable/disable so Chromium returns a
+  // system-audio track instead of microphone audio.
+  enableLoopbackAudio: (): Promise<void> => ipcRenderer.invoke('enable-loopback-audio'),
+  disableLoopbackAudio: (): Promise<void> => ipcRenderer.invoke('disable-loopback-audio'),
+  writeSystemAudioChunk: (chunk: ArrayBuffer): Promise<number> =>
+    ipcRenderer.invoke('recording:write-system-audio', chunk),
+  onStopSystemAudio: (callback: () => void) => {
+    const listener = () => callback()
+    ipcRenderer.on('recorder:stop-system-audio', listener)
+    return () => ipcRenderer.removeListener('recorder:stop-system-audio', listener)
+  },
 
   getDisplays: (): Promise<DisplayInfo[]> => ipcRenderer.invoke('desktop:get-displays'),
   getDshowDevices: (): Promise<{ video: DshowDevice[]; audio: DshowDevice[] }> =>

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -99,6 +99,7 @@ export const electronAPI = {
   disableLoopbackAudio: (): Promise<void> => ipcRenderer.invoke('disable-loopback-audio'),
   writeSystemAudioChunk: (chunk: ArrayBuffer): Promise<number> =>
     ipcRenderer.invoke('recording:write-system-audio', chunk),
+  notifySystemAudioStopped: (): Promise<void> => ipcRenderer.invoke('recording:system-audio-stopped'),
   onStopSystemAudio: (callback: () => void) => {
     const listener = () => callback()
     ipcRenderer.on('recorder:stop-system-audio', listener)

--- a/electron/test/stubs/electron-log-main.ts
+++ b/electron/test/stubs/electron-log-main.ts
@@ -1,0 +1,11 @@
+// Test stub: electron-log/main routes to console so unit tests don't boot Electron.
+
+const log = {
+  info: (...args: unknown[]) => console.info('[log:info]', ...args),
+  warn: (...args: unknown[]) => console.warn('[log:warn]', ...args),
+  error: (...args: unknown[]) => console.error('[log:error]', ...args),
+  debug: (...args: unknown[]) => console.debug('[log:debug]', ...args),
+  verbose: (...args: unknown[]) => console.log('[log:verbose]', ...args),
+}
+
+export default log

--- a/electron/test/stubs/electron.ts
+++ b/electron/test/stubs/electron.ts
@@ -1,0 +1,41 @@
+// Test stub: minimal surface of the electron module so plain-Node imports don't fail.
+// Tests that need real Electron behavior should mock this themselves.
+
+export const app = {
+  isPackaged: false,
+  getPath: () => '/tmp',
+  getVersion: () => '0.0.0-test',
+  quit: () => {},
+  on: () => {},
+  whenReady: () => Promise.resolve(),
+}
+
+export const ipcMain = {
+  on: () => {},
+  handle: () => {},
+  removeAllListeners: () => {},
+  once: () => {},
+}
+
+export const BrowserWindow = class {}
+export const Tray = class {}
+export const Menu = { buildFromTemplate: () => ({}), setApplicationMenu: () => {} }
+export const dialog = {
+  showErrorBox: () => {},
+  showOpenDialog: () => Promise.resolve({ canceled: true, filePaths: [] }),
+  showSaveDialog: () => Promise.resolve({ canceled: true, filePath: undefined }),
+}
+export const screen = {
+  getAllDisplays: () => [],
+  getPrimaryDisplay: () => ({ id: 0, bounds: { x: 0, y: 0, width: 0, height: 0 }, scaleFactor: 1, size: { width: 0, height: 0 } }),
+}
+export const systemPreferences = {
+  getMediaAccessStatus: () => 'granted',
+  askForMediaAccess: () => Promise.resolve(true),
+}
+export const nativeImage = { createFromPath: () => ({}) }
+export const session = {
+  defaultSession: {
+    setDisplayMediaRequestHandler: () => {},
+  },
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@tailwindcss/vite": "^4.1.13",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "electron-audio-loopback": "^1.0.6",
         "electron-log": "^5.4.3",
         "electron-store": "^10.1.0",
         "immer": "^10.1.3",
@@ -39,7 +40,7 @@
         "@typescript-eslint/eslint-plugin": "^7.1.1",
         "@typescript-eslint/parser": "^7.1.1",
         "@vitejs/plugin-react": "^4.2.1",
-        "electron": "^30.0.1",
+        "electron": "^31.0.1",
         "electron-builder": "^24.13.3",
         "eslint": "^8.57.0",
         "eslint-config-prettier": "^10.1.8",
@@ -52,7 +53,8 @@
         "typescript": "^5.5.4",
         "vite": "^5.1.6",
         "vite-plugin-electron": "^0.28.6",
-        "vite-plugin-node-polyfills": "^0.24.0"
+        "vite-plugin-node-polyfills": "^0.24.0",
+        "vitest": "^2.1.9"
       },
       "engines": {
         "node": ">=18 <=22"
@@ -464,7 +466,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@electron/get/-/get-2.0.3.tgz",
       "integrity": "sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.1.1",
@@ -486,7 +487,6 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
       "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -501,7 +501,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-      "dev": true,
       "license": "MIT",
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
@@ -511,7 +510,6 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -521,7 +519,6 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4.0.0"
@@ -3333,7 +3330,6 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
       "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -3359,7 +3355,6 @@
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
       "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "defer-to-connect": "^2.0.0"
@@ -3744,7 +3739,6 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
       "integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/http-cache-semantics": "*",
@@ -3783,14 +3777,12 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
       "integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/keyv": {
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
       "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -3807,7 +3799,6 @@
       "version": "20.19.19",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.19.tgz",
       "integrity": "sha512-pb1Uqj5WJP7wrcbLU7Ru4QtA0+3kAXrkutGiD26wUKzSMgNNaPARTUDQmElUXp64kh3cWdou3Q0C7qwwxqSFmg==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -3864,7 +3855,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
       "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -3882,7 +3872,6 @@
       "version": "2.10.3",
       "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
       "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -4108,6 +4097,129 @@
       },
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@xmldom/xmldom": {
@@ -4716,6 +4828,16 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/astral-regex": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
@@ -4893,7 +5015,6 @@
       "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
       "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
       "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -5140,7 +5261,6 @@
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "*"
@@ -5219,11 +5339,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/cacheable-lookup": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
       "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.6.0"
@@ -5233,7 +5362,6 @@
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
       "integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "clone-response": "^1.0.2",
@@ -5329,6 +5457,23 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -5354,6 +5499,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/chownr": {
@@ -5542,7 +5697,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
       "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mimic-response": "^1.0.0"
@@ -6167,7 +6321,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -6185,7 +6338,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
       "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mimic-response": "^3.1.0"
@@ -6201,13 +6353,22 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
       "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/deep-extend": {
@@ -6231,7 +6392,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
       "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -6241,7 +6401,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
       "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0",
@@ -6259,7 +6419,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
       "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.0.1",
@@ -6307,7 +6467,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
       "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -6576,10 +6735,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "30.5.1",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-30.5.1.tgz",
-      "integrity": "sha512-AhL7+mZ8Lg14iaNfoYTkXQ2qee8mmsQyllKdqxlpv/zrKgfxz6jNVtcRRbQtLxtF8yzcImWdfTQROpYiPumdbw==",
-      "dev": true,
+      "version": "31.7.7",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-31.7.7.tgz",
+      "integrity": "sha512-HZtZg8EHsDGnswFt0QeV8If8B+et63uD6RJ7I4/xhcXqmTIbI08GoubX/wm+HdY0DwcuPe1/xsgqpmYvjdjRoA==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -6592,6 +6750,15 @@
       },
       "engines": {
         "node": ">= 12.20.55"
+      }
+    },
+    "node_modules/electron-audio-loopback": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/electron-audio-loopback/-/electron-audio-loopback-1.0.6.tgz",
+      "integrity": "sha512-QW0ogDqMpWHDAQHmQyssJ+Yh4qR3kWCP3Q4H9WuIXKwVlgkqOYGyt0v/JzbK3tBNTwfqbuHZy86kwCCajxqAdg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "electron": ">=31.0.1"
       }
     },
     "node_modules/electron-builder": {
@@ -6734,7 +6901,6 @@
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
@@ -6915,7 +7081,6 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
       "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -7024,7 +7189,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7034,7 +7199,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7067,6 +7232,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -7132,7 +7304,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
       "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -7188,7 +7359,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -7605,6 +7776,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/exponential-backoff": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.2.tgz",
@@ -7616,7 +7797,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
       "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "debug": "^4.1.1",
@@ -7748,7 +7928,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
       "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pend": "~1.2.0"
@@ -8233,7 +8412,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
       "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pump": "^3.0.0"
@@ -8295,7 +8473,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
       "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "optional": true,
       "dependencies": {
@@ -8355,7 +8532,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
       "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "define-properties": "^1.2.1",
@@ -8393,7 +8570,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -8406,7 +8583,6 @@
       "version": "11.8.6",
       "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
       "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@sindresorhus/is": "^4.0.0",
@@ -8490,7 +8666,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0"
@@ -8654,7 +8830,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
       "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
-      "devOptional": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/http-proxy-agent": {
@@ -8676,7 +8851,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
       "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "quick-lru": "^5.1.1",
@@ -9637,7 +9811,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-parse-better-errors": {
@@ -9678,7 +9851,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
-      "dev": true,
       "license": "ISC",
       "optional": true
     },
@@ -9728,7 +9900,6 @@
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
       "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
@@ -10194,11 +10365,17 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lowercase-keys": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
       "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -10288,7 +10465,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
       "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -10460,7 +10636,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
       "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -10603,7 +10778,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/mz": {
@@ -11098,7 +11272,6 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
       "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -13847,7 +14020,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -13932,7 +14105,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -14001,7 +14173,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
       "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -14314,6 +14485,23 @@
         "node": ">=8"
       }
     },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
     "node_modules/pbkdf2": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.5.tgz",
@@ -14336,7 +14524,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/picocolors": {
@@ -14587,7 +14774,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -14652,7 +14838,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
       "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "end-of-stream": "^1.1.0",
@@ -14719,7 +14904,6 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
       "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -15083,7 +15267,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
       "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/resolve-from": {
@@ -15100,7 +15283,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
       "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "lowercase-keys": "^2.0.0"
@@ -15274,7 +15456,6 @@
       "version": "2.15.4",
       "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
       "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "optional": true,
       "dependencies": {
@@ -15784,7 +15965,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
       "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -15822,7 +16002,6 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
       "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -15839,7 +16018,6 @@
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
       "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
-      "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "optional": true,
       "engines": {
@@ -16024,6 +16202,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/signal-exit": {
       "version": "3.0.7",
@@ -16303,9 +16488,15 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
       "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "optional": true
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stat-mode": {
       "version": "1.0.0",
@@ -16316,6 +16507,13 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
@@ -16614,7 +16812,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz",
       "integrity": "sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "debug": "^4.1.0"
@@ -16966,6 +17163,20 @@
         "node": ">=0.6.0"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -16981,6 +17192,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tmp": {
@@ -17246,7 +17487,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unicode-emoji-modifier-base": {
@@ -17543,6 +17783,29 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/vite-plugin-electron": {
       "version": "0.28.8",
       "resolved": "https://registry.npmjs.org/vite-plugin-electron/-/vite-plugin-electron-0.28.8.tgz",
@@ -17573,6 +17836,72 @@
       },
       "peerDependencies": {
         "vite": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
       }
     },
     "node_modules/vm-browserify": {
@@ -17693,6 +18022,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -17751,7 +18097,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/x11": {
@@ -17832,7 +18177,6 @@
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
       "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer-crc32": "~0.2.3",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "postinstall": "electron-builder install-app-deps"
   },
   "dependencies": {
@@ -42,6 +44,7 @@
     "@tailwindcss/vite": "^4.1.13",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "electron-audio-loopback": "^1.0.6",
     "electron-log": "^5.4.3",
     "electron-store": "^10.1.0",
     "immer": "^10.1.3",
@@ -65,7 +68,7 @@
     "@typescript-eslint/eslint-plugin": "^7.1.1",
     "@typescript-eslint/parser": "^7.1.1",
     "@vitejs/plugin-react": "^4.2.1",
-    "electron": "^30.0.1",
+    "electron": "^31.0.1",
     "electron-builder": "^24.13.3",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^10.1.8",
@@ -78,7 +81,8 @@
     "typescript": "^5.5.4",
     "vite": "^5.1.6",
     "vite-plugin-electron": "^0.28.6",
-    "vite-plugin-node-polyfills": "^0.24.0"
+    "vite-plugin-node-polyfills": "^0.24.0",
+    "vitest": "^2.1.9"
   },
   "optionalDependencies": {
     "global-mouse-events": "github:tamnguyenvan/global-mouse-events",
@@ -122,9 +126,13 @@
       "gatekeeperAssess": false,
       "mergeASARs": false,
       "x64ArchFiles": "*",
-      "minimumSystemVersion": "12.0.0",
+      "minimumSystemVersion": "12.3.0",
       "category": "public.app-category.video",
       "type": null,
+      "extendInfo": {
+        "NSAudioCaptureUsageDescription": "ScreenArc captures system audio so you can include it in your screen recordings.",
+        "NSMicrophoneUsageDescription": "ScreenArc records from the microphone when you enable it during a recording."
+      },
       "target": [
         {
           "target": "dmg",

--- a/package.json
+++ b/package.json
@@ -122,13 +122,15 @@
       "artifactName": "${productName} Setup ${version}.${ext}"
     },
     "mac": {
-      "hardenedRuntime": false,
+      "hardenedRuntime": true,
       "gatekeeperAssess": false,
       "mergeASARs": false,
       "x64ArchFiles": "*",
       "minimumSystemVersion": "12.3.0",
       "category": "public.app-category.video",
       "type": null,
+      "entitlements": "resources/entitlements.mac.plist",
+      "entitlementsInherit": "resources/entitlements.mac.plist",
       "extendInfo": {
         "NSAudioCaptureUsageDescription": "ScreenArc captures system audio so you can include it in your screen recordings.",
         "NSMicrophoneUsageDescription": "ScreenArc records from the microphone when you enable it during a recording."

--- a/resources/entitlements.mac.plist
+++ b/resources/entitlements.mac.plist
@@ -14,6 +14,8 @@
 	<true/>
 	<key>com.apple.security.cs.disable-library-validation</key>
 	<true/>
+	<key>com.apple.security.device.audio-input</key>
+	<true/>
 	<key>com.apple.security.files.user-selected.read-write</key>
 	<true/>
 	<key>com.apple.security.inherit</key>

--- a/src/lib/system-audio.ts
+++ b/src/lib/system-audio.ts
@@ -7,6 +7,7 @@
 // Opus encoder (lower CPU and no extra resampling).
 
 const CHUNK_INTERVAL_MS = 1000
+let loopbackCaptureLock: Promise<void> = Promise.resolve()
 
 export interface SystemAudioCaptureHandle {
   stop: () => Promise<void>
@@ -32,16 +33,27 @@ export interface StartOptions {
  */
 export async function startSystemAudioCapture(opts: StartOptions = {}): Promise<SystemAudioCaptureHandle> {
   const api = window.electronAPI
-
-  // Toggle the loopback flag so the next getDisplayMedia() returns a
-  // system-audio track. We disable the flag immediately after the call so
-  // unrelated screen-share requests later don't accidentally pick it up.
-  await api.enableLoopbackAudio()
   let stream: MediaStream
+  let releaseLoopbackLock!: () => void
+  const priorLoopbackLock = loopbackCaptureLock
+  loopbackCaptureLock = new Promise<void>((resolve) => {
+    releaseLoopbackLock = resolve
+  })
+
   try {
-    stream = await navigator.mediaDevices.getDisplayMedia({ audio: true, video: true })
+    await priorLoopbackLock
+
+    // Toggle the loopback flag so the next getDisplayMedia() returns a
+    // system-audio track. We disable the flag immediately after the call so
+    // unrelated screen-share requests later don't accidentally pick it up.
+    await api.enableLoopbackAudio()
+    try {
+      stream = await navigator.mediaDevices.getDisplayMedia({ audio: true, video: true })
+    } finally {
+      await api.disableLoopbackAudio()
+    }
   } finally {
-    await api.disableLoopbackAudio()
+    releaseLoopbackLock()
   }
 
   // We only want audio; drop video tracks immediately.
@@ -71,16 +83,26 @@ export async function startSystemAudioCapture(opts: StartOptions = {}): Promise<
   }
 
   let active = true
+  const pendingChunkWrites = new Set<Promise<void>>()
 
   recorder.ondataavailable = async (event: BlobEvent) => {
     if (!event.data || event.data.size === 0) return
+    const writeTask = (async () => {
+      try {
+        const buf = await event.data.arrayBuffer()
+        await api.writeSystemAudioChunk(buf)
+      } catch (err) {
+        console.error('[SystemAudio] Failed to forward chunk:', err)
+        // We don't kill the capture on transient IPC failures; the writer
+        // serializes chunks and surfaces hard errors at finalize time.
+      }
+    })()
+
+    pendingChunkWrites.add(writeTask)
     try {
-      const buf = await event.data.arrayBuffer()
-      await api.writeSystemAudioChunk(buf)
-    } catch (err) {
-      console.error('[SystemAudio] Failed to forward chunk:', err)
-      // We don't kill the capture on transient IPC failures; the writer
-      // serializes chunks and surfaces hard errors at finalize time.
+      await writeTask
+    } finally {
+      pendingChunkWrites.delete(writeTask)
     }
   }
 
@@ -129,6 +151,8 @@ export async function startSystemAudioCapture(opts: StartOptions = {}): Promise<
         // ignore
       }
     })
+
+    await Promise.allSettled(Array.from(pendingChunkWrites))
   }
 
   return {

--- a/src/lib/system-audio.ts
+++ b/src/lib/system-audio.ts
@@ -1,0 +1,138 @@
+// Renderer-side helper for capturing macOS system audio via
+// electron-audio-loopback + MediaRecorder, streaming WebM/Opus chunks to the
+// main process over IPC.
+//
+// We intentionally avoid pulling the audio into a Web Audio graph: passing the
+// raw MediaStream directly to MediaRecorder lets Chromium use the native macOS
+// Opus encoder (lower CPU and no extra resampling).
+
+const CHUNK_INTERVAL_MS = 1000
+
+export interface SystemAudioCaptureHandle {
+  stop: () => Promise<void>
+  /** True until stop() resolves. Useful for guarding cleanup. */
+  isActive: () => boolean
+}
+
+export interface StartOptions {
+  /** Bitrate hint for the MediaRecorder. Default: 128 kbps. */
+  audioBitsPerSecond?: number
+  /** Called if capture setup fails after the recording has already started. */
+  onError?: (err: Error) => void
+}
+
+/**
+ * Begin capturing system audio. The returned handle lets the caller stop
+ * capture explicitly; capture also stops automatically if the underlying
+ * MediaRecorder errors out.
+ *
+ * Throws if permission is denied, the platform doesn't support loopback, or
+ * the API is otherwise unavailable. Caller should treat this as recoverable —
+ * the screen recording can proceed without system audio.
+ */
+export async function startSystemAudioCapture(opts: StartOptions = {}): Promise<SystemAudioCaptureHandle> {
+  const api = window.electronAPI
+
+  // Toggle the loopback flag so the next getDisplayMedia() returns a
+  // system-audio track. We disable the flag immediately after the call so
+  // unrelated screen-share requests later don't accidentally pick it up.
+  await api.enableLoopbackAudio()
+  let stream: MediaStream
+  try {
+    stream = await navigator.mediaDevices.getDisplayMedia({ audio: true, video: true })
+  } finally {
+    await api.disableLoopbackAudio()
+  }
+
+  // We only want audio; drop video tracks immediately.
+  stream.getVideoTracks().forEach((track) => {
+    try {
+      track.stop()
+    } catch {
+      // ignore
+    }
+    stream.removeTrack(track)
+  })
+
+  if (stream.getAudioTracks().length === 0) {
+    stream.getTracks().forEach((t) => t.stop())
+    throw new Error('System audio capture returned no audio tracks (NSAudioCaptureUsageDescription missing?)')
+  }
+
+  let recorder: MediaRecorder
+  try {
+    recorder = new MediaRecorder(stream, {
+      mimeType: 'audio/webm;codecs=opus',
+      audioBitsPerSecond: opts.audioBitsPerSecond ?? 128_000,
+    })
+  } catch (err) {
+    stream.getTracks().forEach((t) => t.stop())
+    throw err instanceof Error ? err : new Error(String(err))
+  }
+
+  let active = true
+
+  recorder.ondataavailable = async (event: BlobEvent) => {
+    if (!event.data || event.data.size === 0) return
+    try {
+      const buf = await event.data.arrayBuffer()
+      await api.writeSystemAudioChunk(buf)
+    } catch (err) {
+      console.error('[SystemAudio] Failed to forward chunk:', err)
+      // We don't kill the capture on transient IPC failures; the writer
+      // serializes chunks and surfaces hard errors at finalize time.
+    }
+  }
+
+  recorder.onerror = (event: Event) => {
+    const err = (event as unknown as { error?: Error }).error ?? new Error('MediaRecorder error')
+    console.error('[SystemAudio] MediaRecorder error:', err)
+    active = false
+    opts.onError?.(err)
+  }
+
+  // Emit a chunk every CHUNK_INTERVAL_MS so the main process sees data
+  // continuously and a crash mid-recording leaves only ~1s of audio at risk.
+  recorder.start(CHUNK_INTERVAL_MS)
+
+  const stop = async () => {
+    if (!active) return
+    active = false
+
+    if (recorder.state !== 'inactive') {
+      // requestData() forces one final ondataavailable before stop() so the
+      // tail of the recording isn't lost.
+      try {
+        recorder.requestData()
+      } catch {
+        // requestData throws if not recording; safe to ignore
+      }
+
+      await new Promise<void>((resolve) => {
+        const onStop = () => {
+          recorder.removeEventListener('stop', onStop)
+          resolve()
+        }
+        recorder.addEventListener('stop', onStop)
+        try {
+          recorder.stop()
+        } catch {
+          resolve()
+        }
+      })
+    }
+
+    stream.getTracks().forEach((t) => {
+      try {
+        t.stop()
+      } catch {
+        // ignore
+      }
+    })
+  }
+
+  return {
+    stop,
+    isActive: () => active,
+  }
+}

--- a/src/pages/RecorderPage.tsx
+++ b/src/pages/RecorderPage.tsx
@@ -56,8 +56,15 @@ export function RecorderPage() {
   const webcamPreviewRef = useRef<HTMLVideoElement>(null)
   const webcamStreamRef = useRef<MediaStream | null>(null)
   const systemAudioHandleRef = useRef<SystemAudioCaptureHandle | null>(null)
+  const actionInProgressRef = useRef<ActionInProgress>('none')
 
   const supportsSystemAudio = platform === 'darwin'
+  const isBusy = actionInProgress !== 'none'
+
+  const setActionState = useCallback((next: ActionInProgress) => {
+    actionInProgressRef.current = next
+    setActionInProgress(next)
+  }, [])
 
   const cursorScales = useMemo(() => (platform === 'win32' ? WINDOWS_SCALES : LINUX_SCALES), [platform])
 
@@ -129,11 +136,11 @@ export function RecorderPage() {
   useEffect(() => {
     const cleanupStarted = window.electronAPI.onRecordingStarted(() => {
       setIsRecording(true)
-      setActionInProgress('none')
+      setActionState('none')
     })
 
     const cleanupFinished = window.electronAPI.onRecordingFinished(() => {
-      setActionInProgress('none')
+      setActionState('none')
       setRecordingState('idle')
       setIsRecording(false)
       // Recording finished (or canceled) — release the MediaRecorder if it's
@@ -145,7 +152,17 @@ export function RecorderPage() {
     // Main process tells us to stop the MediaRecorder before it finalizes the
     // writer. We honor it eagerly so the tail chunk is flushed.
     const cleanupStopSystemAudio = window.electronAPI.onStopSystemAudio?.(() => {
-      void stopSystemAudio()
+      void (async () => {
+        try {
+          await stopSystemAudio()
+        } finally {
+          try {
+            await window.electronAPI.notifySystemAudioStopped()
+          } catch (error) {
+            console.error('[Recorder] Failed to acknowledge system-audio stop to main process:', error)
+          }
+        }
+      })()
     })
 
     return () => {
@@ -153,7 +170,7 @@ export function RecorderPage() {
       cleanupFinished()
       cleanupStopSystemAudio?.()
     }
-  }, [reloadDevices, stopSystemAudio])
+  }, [reloadDevices, setActionState, stopSystemAudio])
 
   // Effect to manage the webcam preview stream
   useEffect(() => {
@@ -188,7 +205,9 @@ export function RecorderPage() {
   }, [selectedWebcamId, platform, recordingState])
 
   const handleStart = async () => {
-    setActionInProgress('recording')
+    if (isRecording || actionInProgressRef.current !== 'none') return
+
+    setActionState('recording')
     if (webcamStreamRef.current) {
       webcamStreamRef.current.getTracks().forEach((track) => track.stop())
       webcamStreamRef.current = null
@@ -230,30 +249,34 @@ export function RecorderPage() {
         // If the user canceled (or main returned canceled), make sure we don't
         // leak the system-audio MediaRecorder we already started.
         await stopSystemAudio()
-        setActionInProgress('none')
+        setActionState('none')
         setIsRecording(false)
       }
     } catch (error) {
       console.error('Failed to start recording:', error)
       await stopSystemAudio()
-      setActionInProgress('none')
+      setActionState('none')
       setIsRecording(false)
     }
   }
 
   const handleStop = () => {
-    setActionInProgress('recording')
+    if (!isRecording || actionInProgressRef.current !== 'none') return
+
+    setActionState('recording')
     window.electronAPI.stopRecording()
   }
 
   const handleLoadVideo = async () => {
-    setActionInProgress('loading')
+    if (isRecording || actionInProgressRef.current !== 'none') return
+
+    setActionState('loading')
     try {
       const result = await window.electronAPI.loadVideoFromFile()
-      if (result.canceled) setActionInProgress('none')
+      if (result.canceled) setActionState('none')
     } catch (error) {
       console.error('Failed to load video from file:', error)
-      setActionInProgress('none')
+      setActionState('none')
     }
   }
 
@@ -283,7 +306,7 @@ export function RecorderPage() {
               style={{ WebkitAppRegion: 'no-drag' }}
               className="absolute -top-2.5 -left-2.5 z-20 flex items-center justify-center w-6 h-6 rounded-full bg-destructive/90 hover:bg-destructive text-white shadow-lg transition-all hover:scale-110"
               aria-label="Close Recorder"
-              disabled={isRecording}
+              disabled={isRecording || isBusy}
             >
               <X className="w-3.5 h-3.5" />
             </button>
@@ -298,14 +321,14 @@ export function RecorderPage() {
                 isActive={source === 'fullscreen'}
                 onClick={() => setSource('fullscreen')}
                 tooltip="Full Screen"
-                disabled={isRecording}
+                disabled={isRecording || isBusy}
               />
               <SourceButton
                 icon={<Marquee2 size={16} />}
                 isActive={source === 'area'}
                 onClick={() => setSource('area')}
                 tooltip="Area"
-                disabled={isRecording}
+                disabled={isRecording || isBusy}
               />
             </div>
 
@@ -316,7 +339,7 @@ export function RecorderPage() {
               <Select
                 value={selectedDisplayId}
                 onValueChange={setSelectedDisplayId}
-                disabled={source !== 'fullscreen' || isRecording}
+                disabled={source !== 'fullscreen' || isRecording || isBusy}
               >
                 <SelectTrigger
                   variant="minimal"
@@ -344,7 +367,7 @@ export function RecorderPage() {
               <Select
                 value={selectedWebcamId}
                 onValueChange={handleSelectionChange(setSelectedWebcamId, 'recorder.selectedWebcamId')}
-                disabled={isRecording}
+                disabled={isRecording || isBusy}
               >
                 <SelectTrigger
                   variant="minimal"
@@ -377,7 +400,7 @@ export function RecorderPage() {
               <Select
                 value={selectedMicId}
                 onValueChange={handleSelectionChange(setSelectedMicId, 'recorder.selectedMicId')}
-                disabled={isRecording}
+                disabled={isRecording || isBusy}
               >
                 <SelectTrigger
                   variant="minimal"
@@ -416,7 +439,7 @@ export function RecorderPage() {
                     setSystemAudioEnabled(next)
                     window.electronAPI.setSetting('recorder.systemAudioEnabled', next)
                   }}
-                  disabled={isRecording}
+                  disabled={isRecording || isBusy}
                   aria-pressed={systemAudioEnabled}
                   aria-label={systemAudioEnabled ? 'Disable system audio recording' : 'Enable system audio recording'}
                   title={
@@ -429,7 +452,7 @@ export function RecorderPage() {
                     systemAudioEnabled
                       ? 'bg-primary/10 border-primary/30 text-primary'
                       : 'bg-muted/40 border-border/50 text-muted-foreground hover:text-foreground hover:bg-background/50',
-                    isRecording && 'opacity-50 cursor-not-allowed',
+                    (isRecording || isBusy) && 'opacity-50 cursor-not-allowed',
                   )}
                 >
                   {systemAudioEnabled ? <Volume size={14} /> : <VolumeOff size={14} />}
@@ -445,7 +468,7 @@ export function RecorderPage() {
               <>
                 <div className="flex items-center gap-1.5" style={{ WebkitAppRegion: 'no-drag' }}>
                   <Pointer size={14} className="text-muted-foreground/60" />
-                  <Select value={String(cursorScale)} onValueChange={handleCursorScaleChange} disabled={isRecording}>
+                  <Select value={String(cursorScale)} onValueChange={handleCursorScaleChange} disabled={isRecording || isBusy}>
                     <SelectTrigger variant="minimal" className="w-[56px] h-9 text-xs" aria-label="Select cursor scale">
                       <SelectValue />
                     </SelectTrigger>
@@ -479,7 +502,7 @@ export function RecorderPage() {
                   <Button
                     onClick={handleStart}
                     title="Record"
-                    disabled={isInitializing || actionInProgress !== 'none'}
+                    disabled={isInitializing || isBusy}
                     size="icon"
                     className="h-10 w-10 rounded-full shadow-lg"
                   >
@@ -489,7 +512,7 @@ export function RecorderPage() {
                 <Button
                   onClick={handleLoadVideo}
                   title="Load from video"
-                  disabled={isInitializing || actionInProgress !== 'none' || isRecording}
+                  disabled={isInitializing || isBusy || isRecording}
                   variant="secondary"
                   size="icon"
                   className="h-10 w-10 rounded-full shadow-lg"

--- a/src/pages/RecorderPage.tsx
+++ b/src/pages/RecorderPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useMemo } from 'react'
+import { useState, useEffect, useRef, useMemo, useCallback } from 'react'
 import {
   Microphone,
   MicrophoneOff,
@@ -12,11 +12,14 @@ import {
   Pointer,
   Folder,
   Square,
+  Volume,
+  VolumeOff,
 } from 'tabler-icons-react'
 import { Button } from '../components/ui/button'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../components/ui/select'
 import { useDeviceManager } from '../hooks/useDeviceManager'
 import { cn } from '../lib/utils'
+import { startSystemAudioCapture, type SystemAudioCaptureHandle } from '../lib/system-audio'
 import '../index.css'
 
 // --- Constants ---
@@ -46,11 +49,15 @@ export function RecorderPage() {
   const [selectedDisplayId, setSelectedDisplayId] = useState<string>('')
   const [selectedWebcamId, setSelectedWebcamId] = useState<string>('none')
   const [selectedMicId, setSelectedMicId] = useState<string>('none')
+  const [systemAudioEnabled, setSystemAudioEnabled] = useState<boolean>(false)
   const [cursorScale, setCursorScale] = useState<number>(1)
 
   const { platform, webcams, mics, isInitializing, reload: reloadDevices } = useDeviceManager()
   const webcamPreviewRef = useRef<HTMLVideoElement>(null)
   const webcamStreamRef = useRef<MediaStream | null>(null)
+  const systemAudioHandleRef = useRef<SystemAudioCaptureHandle | null>(null)
+
+  const supportsSystemAudio = platform === 'darwin'
 
   const cursorScales = useMemo(() => (platform === 'win32' ? WINDOWS_SCALES : LINUX_SCALES), [platform])
 
@@ -58,15 +65,18 @@ export function RecorderPage() {
   useEffect(() => {
     const initialize = async () => {
       try {
-        const [savedWebcamId, savedMicId, savedCursorScale, fetchedDisplays] = await Promise.all([
+        const [savedWebcamId, savedMicId, savedSystemAudio, savedCursorScale, fetchedDisplays] = await Promise.all([
           window.electronAPI.getSetting<string>('recorder.selectedWebcamId'),
           window.electronAPI.getSetting<string>('recorder.selectedMicId'),
+          window.electronAPI.getSetting<boolean>('recorder.systemAudioEnabled'),
           window.electronAPI.getSetting<number>('recorder.cursorScale'),
           window.electronAPI.getDisplays(),
         ])
 
         setSelectedWebcamId(savedWebcamId || 'none')
         setSelectedMicId(savedMicId || 'none')
+        // Only honor a saved value when the platform supports system audio.
+        setSystemAudioEnabled(platform === 'darwin' && !!savedSystemAudio)
 
         // Only set cursor scale from settings for Linux
         if (platform === 'linux') {
@@ -101,6 +111,20 @@ export function RecorderPage() {
     }
   }, [isInitializing, webcams, mics, platform, cursorScales, selectedWebcamId, selectedMicId, cursorScale])
 
+  // Best-effort: stop the active system-audio capture, releasing tracks
+  // and flushing the final MediaRecorder chunk.
+  const stopSystemAudio = useCallback(async () => {
+    const handle = systemAudioHandleRef.current
+    systemAudioHandleRef.current = null
+    if (handle) {
+      try {
+        await handle.stop()
+      } catch (err) {
+        console.error('[Recorder] Failed to stop system audio capture:', err)
+      }
+    }
+  }, [])
+
   // Effect to manage IPC listeners for recording completion
   useEffect(() => {
     const cleanupStarted = window.electronAPI.onRecordingStarted(() => {
@@ -112,13 +136,24 @@ export function RecorderPage() {
       setActionInProgress('none')
       setRecordingState('idle')
       setIsRecording(false)
+      // Recording finished (or canceled) — release the MediaRecorder if it's
+      // still alive. Main process has already finalized the writer.
+      void stopSystemAudio()
       reloadDevices() // Refresh device list in case something changed
     })
+
+    // Main process tells us to stop the MediaRecorder before it finalizes the
+    // writer. We honor it eagerly so the tail chunk is flushed.
+    const cleanupStopSystemAudio = window.electronAPI.onStopSystemAudio?.(() => {
+      void stopSystemAudio()
+    })
+
     return () => {
       cleanupStarted()
       cleanupFinished()
+      cleanupStopSystemAudio?.()
     }
-  }, [reloadDevices])
+  }, [reloadDevices, stopSystemAudio])
 
   // Effect to manage the webcam preview stream
   useEffect(() => {
@@ -164,20 +199,43 @@ export function RecorderPage() {
     try {
       const webcam = selectedWebcamId !== 'none' ? webcams.find((d) => d.id === selectedWebcamId) : undefined
       const mic = selectedMicId !== 'none' ? mics.find((d) => d.id === selectedMicId) : undefined
+      const wantSystemAudio = systemAudioEnabled && supportsSystemAudio
+
+      // Set up system-audio capture *before* starting the recording so the TCC
+      // permission prompt fires up-front rather than mid-recording. If it fails
+      // (denied, unsupported), we proceed without system audio rather than
+      // blocking the entire recording.
+      let systemAudioReady = false
+      if (wantSystemAudio) {
+        try {
+          systemAudioHandleRef.current = await startSystemAudioCapture({
+            onError: (err) => console.error('[Recorder] System audio capture failed mid-recording:', err),
+          })
+          systemAudioReady = true
+        } catch (err) {
+          console.error('[Recorder] Could not start system audio capture; proceeding without it.', err)
+          systemAudioHandleRef.current = null
+        }
+      }
 
       const result = await window.electronAPI.startRecording({
         source,
         displayId: source === 'fullscreen' ? Number(selectedDisplayId) : undefined,
         webcam: webcam ? { deviceId: webcam.id, deviceLabel: webcam.id, index: webcams.indexOf(webcam) } : undefined,
         mic: mic ? { deviceId: mic.id, deviceLabel: mic.id, index: mics.indexOf(mic) } : undefined,
+        systemAudio: systemAudioReady,
       })
 
       if (result.canceled) {
+        // If the user canceled (or main returned canceled), make sure we don't
+        // leak the system-audio MediaRecorder we already started.
+        await stopSystemAudio()
         setActionInProgress('none')
         setIsRecording(false)
       }
     } catch (error) {
       console.error('Failed to start recording:', error)
+      await stopSystemAudio()
       setActionInProgress('none')
       setIsRecording(false)
     }
@@ -348,6 +406,36 @@ export function RecorderPage() {
                   ))}
                 </SelectContent>
               </Select>
+
+              {/* System Audio Toggle (macOS only) */}
+              {supportsSystemAudio && (
+                <button
+                  type="button"
+                  onClick={() => {
+                    const next = !systemAudioEnabled
+                    setSystemAudioEnabled(next)
+                    window.electronAPI.setSetting('recorder.systemAudioEnabled', next)
+                  }}
+                  disabled={isRecording}
+                  aria-pressed={systemAudioEnabled}
+                  aria-label={systemAudioEnabled ? 'Disable system audio recording' : 'Enable system audio recording'}
+                  title={
+                    systemAudioEnabled
+                      ? 'System audio: ON (recording desktop sound)'
+                      : 'System audio: OFF (click to enable)'
+                  }
+                  className={cn(
+                    'flex items-center gap-1.5 h-9 px-2.5 rounded-lg border text-xs transition-all',
+                    systemAudioEnabled
+                      ? 'bg-primary/10 border-primary/30 text-primary'
+                      : 'bg-muted/40 border-border/50 text-muted-foreground hover:text-foreground hover:bg-background/50',
+                    isRecording && 'opacity-50 cursor-not-allowed',
+                  )}
+                >
+                  {systemAudioEnabled ? <Volume size={14} /> : <VolumeOff size={14} />}
+                  <span className="truncate">System audio</span>
+                </button>
+              )}
             </div>
 
             <div className="w-px h-8 bg-border/50"></div>

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'vitest/config'
+import path from 'node:path'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['electron/**/*.test.ts', 'src/**/*.test.ts'],
+    globals: false,
+    testTimeout: 10000,
+  },
+  resolve: {
+    // Stub electron and electron-log/main so plain-Node unit tests don't try to
+    // boot the real Electron runtime.
+    alias: {
+      'electron-log/main': path.resolve(__dirname, 'electron/test/stubs/electron-log-main.ts'),
+      'electron-log': path.resolve(__dirname, 'electron/test/stubs/electron-log-main.ts'),
+      electron: path.resolve(__dirname, 'electron/test/stubs/electron.ts'),
+    },
+  },
+})


### PR DESCRIPTION
Closes #145

## What this adds

A **System audio** toggle on the recorder bar (macOS only). When enabled, ScreenArc captures whatever is playing through your speakers — music, video, system sounds — and mixes it into the final MP4 alongside the screen recording and optional microphone.

- Toggle lives next to the mic selector; hidden on Windows and Linux.
- System audio preference is persisted across sessions.
- Both mic and system audio can be on at the same time; they're mixed via FFmpeg's `amix` filter.
- On first use, macOS shows a one-time permission prompt ("ScreenArc would like to record this computer's audio").

## How it works

macOS does not expose system audio to FFmpeg's `avfoundation` input, so the capture has to happen inside the app. This PR uses [`electron-audio-loopback`](https://github.com/nicholaswboyer/electron-audio-loopback), which drives Chromium's built-in `getDisplayMedia({audio})` call. On macOS 14.4+ it takes the CoreAudio Tap path (audio-only TCC prompt, no purple Control Center indicator); on 12.3–14.3 it falls back to ScreenCaptureKit.

```
During recording
  Main process:    FFmpeg #1 → <id>-screen.mp4   (screen + optional mic, unchanged)
  Renderer:        MediaRecorder(opus@128kbps).start(1000ms)
                   ondataavailable → IPC → main writer → <id>-system.webm

On stop
  FFmpeg #2 (mux): screen.mp4 + system.webm → amix → final screen.mp4
```

Key design properties carried over from ScreenArc's existing model:
- **Disk-bounded**: renderer streams 1-second WebM clusters over IPC; nothing accumulates in memory.
- **Crash-resilient**: WebM clusters are independently parseable; partial files are recoverable.
- **Graceful degradation**: permission denied or renderer failure → recording still completes, just without system audio. Mux failure → original screen file is kept intact.

## Files changed

**New:**
- `electron/main/features/system-audio-writer.ts` — append-only IPC chunk writer with a serialized promise queue and full lifecycle (`start`/`finalize`/`abort`).
- `electron/main/features/build-mux-args.ts` — pure function building FFmpeg mux args for all combinations of mic / system audio.
- `src/lib/system-audio.ts` — renderer helper wrapping `getDisplayMedia`, `MediaRecorder`, and IPC chunk forwarding.
- `vitest.config.ts` + `electron/test/stubs/` — unit test scaffolding with Electron stubs.

**Modified:**
- `electron/main/features/recording-manager.ts` — wires up the writer, mux step, and cleanup paths.
- `electron/main/index.ts` — calls `initAudioLoopback({ forceCoreAudioTap: true })` before `app.whenReady()`.
- `electron/main/windows/recorder-window.ts` — `backgroundThrottling: false` (prevents macOS from throttling the hidden renderer's MediaRecorder).
- `src/pages/RecorderPage.tsx` — System audio toggle UI, persisted preference, `MediaRecorder` lifecycle.
- `package.json` — adds `electron-audio-loopback`, bumps Electron 30 → 31, adds vitest, bumps macOS `minimumSystemVersion` 12.0 → 12.3, adds `NSAudioCaptureUsageDescription` to the Mac build's `extendInfo`.
- `resources/entitlements.mac.plist` — adds `com.apple.security.device.audio-input` (required for signed/notarized builds).

## Tests

15 unit tests, all passing (`npm test`):

**`SystemAudioWriter` (10 tests):** write before start is a no-op; write + finalize round-trip; concurrent writes serialize; abort prevents writes; start after finalize; start rejects if session still active; finalize rejects after stream error; directory auto-created.

**`buildMuxArgs` (5 tests):** mic + system → `amix`; system only → `aresample`; mic only → stream-copy; no audio → stream-copy; paths with spaces handled correctly.

## Manual test checklist (macOS 12.3+)

```bash
git checkout feat/macos-system-audio
npm install   # electron 31 + electron-audio-loopback
npm test      # 15 tests should pass
npm run dev
```

- [ ] First-run permission prompt appears and can be granted
- [ ] System audio only: desktop audio audible in final MP4
- [ ] System audio + mic: both audible, mixed sensibly
- [ ] Toggle persists across app restarts
- [ ] Permission denied: recording completes normally without system audio
- [ ] Cancel mid-recording: no orphan `-system.webm` files left behind

## Platform scope

Windows and Linux system audio are **out of scope** for this PR — different OS APIs. The toggle is hidden on those platforms and the flag is silently ignored in `recording-manager.ts`.

## Risk

The mux step runs at the end of every recording that has system audio enabled. If the mux fails (disk full, etc.) the original screen file is preserved — there is no path where a mux failure corrupts an existing recording. The only user-visible change on upgrade is a one-time macOS permission prompt on the first recording with system audio; all existing behavior is unchanged if the toggle is off.