### PR TITLE
fix(macos): Add support for Mac OS 14+ via ScreenCaptureKit and system audio robustness

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,6 @@ A huge thank you to everyone who has contributed to making ScreenArc better!
 ScreenArc stands on the shoulders of giants. This project would not be possible without the incredible work of the open-source community. A special thank you to the authors and maintainers of these key libraries & tools that handle low-level system interactions:
 
 - [global-mouse-events](https://github.com/xanderfrangos/global-mouse-events): Mouse event listener on Windows
-- [iohook-macos](https://github.com/hwanyong/iohook-macos): Mouse event listener on macOS
 - [node-x11](https://github.com/sidorares/node-x11): X11 Node.js binding
 - [Cursorful](https://cursorful.com/): I borrowed the Timeline design idea from them.
 

--- a/electron/main/features/build-mux-args.test.ts
+++ b/electron/main/features/build-mux-args.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, test } from 'vitest'
-import { buildMuxArgs } from './build-mux-args'
+import { buildMuxArgs, buildMacMuxArgs } from './build-mux-args'
 
 const SCREEN = '/tmp/screen.mp4'
 const SYS = '/tmp/system.webm'
 const OUT = '/tmp/final.mp4'
+const WEBM = '/tmp/screen.webm'
+const MIC = '/tmp/mic.m4a'
 
 describe('buildMuxArgs', () => {
   test('mic + system: amix two streams, copy video', () => {
@@ -98,6 +100,116 @@ describe('buildMuxArgs', () => {
     expect(args).toContain('/tmp/with space/system.webm')
     expect(args).toContain('/tmp/with space/out.mp4')
     // No bash-style quoting in args
+    args.forEach((a) => expect(a).not.toMatch(/^".*"$/))
+  })
+})
+
+describe('buildMacMuxArgs', () => {
+  test('webm with system audio + mic: amix two streams, transcode video', () => {
+    const args = buildMacMuxArgs({
+      screenWebmInput: WEBM,
+      micAudioInput: MIC,
+      output: OUT,
+      webmHasSystemAudio: true,
+    })
+
+    expect(args).toEqual([
+      '-y',
+      '-i', WEBM,
+      '-i', MIC,
+      '-filter_complex',
+      '[0:a][1:a]amix=inputs=2:duration=first:dropout_transition=0,aresample=async=1[a]',
+      '-map', '0:v',
+      '-map', '[a]',
+      '-c:v', 'libx264',
+      '-preset', 'ultrafast',
+      '-pix_fmt', 'yuv420p',
+      '-c:a', 'aac',
+      '-b:a', '192k',
+      '-shortest',
+      OUT,
+    ])
+  })
+
+  test('webm with system audio only: aresample audio, transcode video', () => {
+    const args = buildMacMuxArgs({
+      screenWebmInput: WEBM,
+      micAudioInput: undefined,
+      output: OUT,
+      webmHasSystemAudio: true,
+    })
+
+    expect(args).toEqual([
+      '-y',
+      '-i', WEBM,
+      '-filter_complex',
+      '[0:a]aresample=async=1[a]',
+      '-map', '0:v',
+      '-map', '[a]',
+      '-c:v', 'libx264',
+      '-preset', 'ultrafast',
+      '-pix_fmt', 'yuv420p',
+      '-c:a', 'aac',
+      '-b:a', '192k',
+      '-shortest',
+      OUT,
+    ])
+  })
+
+  test('mic only (no system audio in webm): copy mic stream, transcode video', () => {
+    const args = buildMacMuxArgs({
+      screenWebmInput: WEBM,
+      micAudioInput: MIC,
+      output: OUT,
+      webmHasSystemAudio: false,
+    })
+
+    expect(args).toEqual([
+      '-y',
+      '-i', WEBM,
+      '-i', MIC,
+      '-map', '0:v',
+      '-map', '1:a',
+      '-c:v', 'libx264',
+      '-preset', 'ultrafast',
+      '-pix_fmt', 'yuv420p',
+      '-c:a', 'copy',
+      '-shortest',
+      OUT,
+    ])
+  })
+
+  test('no audio at all: video-only output with -an', () => {
+    const args = buildMacMuxArgs({
+      screenWebmInput: WEBM,
+      micAudioInput: undefined,
+      output: OUT,
+      webmHasSystemAudio: false,
+    })
+
+    expect(args).toEqual([
+      '-y',
+      '-i', WEBM,
+      '-map', '0:v',
+      '-c:v', 'libx264',
+      '-preset', 'ultrafast',
+      '-pix_fmt', 'yuv420p',
+      '-an',
+      OUT,
+    ])
+  })
+
+  test('paths with spaces are not pre-quoted (spawn handles them)', () => {
+    const args = buildMacMuxArgs({
+      screenWebmInput: '/tmp/with space/screen.webm',
+      micAudioInput: '/tmp/with space/mic.m4a',
+      output: '/tmp/with space/out.mp4',
+      webmHasSystemAudio: true,
+    })
+
+    expect(args).toContain('/tmp/with space/screen.webm')
+    expect(args).toContain('/tmp/with space/mic.m4a')
+    expect(args).toContain('/tmp/with space/out.mp4')
     args.forEach((a) => expect(a).not.toMatch(/^".*"$/))
   })
 })

--- a/electron/main/features/build-mux-args.ts
+++ b/electron/main/features/build-mux-args.ts
@@ -42,3 +42,89 @@ export function buildMuxArgs(opts: BuildMuxArgsOptions): string[] {
     output,
   ]
 }
+
+// macOS variant: the screen capture is a renderer-produced WebM (VP9 +
+// optional Opus loopback audio). Optional mic audio is captured by FFmpeg
+// to its own AAC/m4a file. Output is MP4 (H.264 + AAC).
+//
+// Layout (only inputs that exist are added):
+//   input 0: screen video (webm) — has video, may have system audio
+//   input 1: mic audio (m4a/aac)  — optional
+//
+// Video is always re-encoded VP9 → H.264. Audio strategy:
+//   - webm has system audio + mic present → amix the two, encode AAC
+//   - webm has system audio only         → aresample, encode AAC
+//   - mic only (no system audio in webm) → copy mic stream from input 1
+//   - neither                            → output has no audio track
+
+export interface BuildMacMuxArgsOptions {
+  screenWebmInput: string
+  micAudioInput: string | undefined
+  output: string
+  webmHasSystemAudio: boolean
+}
+
+export function buildMacMuxArgs(opts: BuildMacMuxArgsOptions): string[] {
+  const { screenWebmInput, micAudioInput, output, webmHasSystemAudio } = opts
+
+  const args: string[] = ['-y', '-i', screenWebmInput]
+  if (micAudioInput) {
+    args.push('-i', micAudioInput)
+  }
+
+  // Common video encode settings — match the existing screen-capture profile.
+  const videoEncode = [
+    '-c:v', 'libx264',
+    '-preset', 'ultrafast',
+    '-pix_fmt', 'yuv420p',
+  ]
+
+  if (webmHasSystemAudio && micAudioInput) {
+    // Mix the two audio sources. duration=first keeps the output as long as
+    // the screen video; aresample corrects clock drift between sources.
+    args.push(
+      '-filter_complex',
+      '[0:a][1:a]amix=inputs=2:duration=first:dropout_transition=0,aresample=async=1[a]',
+      '-map', '0:v',
+      '-map', '[a]',
+      ...videoEncode,
+      '-c:a', 'aac',
+      '-b:a', '192k',
+      '-shortest',
+      output,
+    )
+    return args
+  }
+
+  if (webmHasSystemAudio) {
+    args.push(
+      '-filter_complex',
+      '[0:a]aresample=async=1[a]',
+      '-map', '0:v',
+      '-map', '[a]',
+      ...videoEncode,
+      '-c:a', 'aac',
+      '-b:a', '192k',
+      '-shortest',
+      output,
+    )
+    return args
+  }
+
+  if (micAudioInput) {
+    // Mic file is already AAC — copy through to avoid double-encoding.
+    args.push(
+      '-map', '0:v',
+      '-map', '1:a',
+      ...videoEncode,
+      '-c:a', 'copy',
+      '-shortest',
+      output,
+    )
+    return args
+  }
+
+  // No audio at all — re-encode video, drop audio explicitly.
+  args.push('-map', '0:v', ...videoEncode, '-an', output)
+  return args
+}

--- a/electron/main/features/mouse-tracker.ts
+++ b/electron/main/features/mouse-tracker.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import log from 'electron-log/main'
 import { EventEmitter } from 'node:events'
-import { dialog } from 'electron'
+import { dialog, screen } from 'electron'
 import { createRequire } from 'node:module'
 import { createHash } from 'node:crypto'
 import { MOUSE_RECORDING_FPS } from '../lib/constants'
@@ -28,7 +28,6 @@ const ANIMATED_CURSORS = {
 // --- Dynamic Imports for Platform-Specific Modules ---
 let X11Module: any
 let mouseEvents: any
-let iohook: any
 
 export function initializeMouseTrackerDependencies() {
   if (process.platform === 'linux') {
@@ -54,13 +53,14 @@ export function initializeMouseTrackerDependencies() {
   }
 
   if (process.platform === 'darwin') {
-    try {
-      iohook = require('iohook-macos')
-      macosCursorManager.initializeMacOSCursorManager()
-      log.info('[MouseTracker] Successfully loaded iohook-macos and initialized macos-cursor-manager for macOS.')
-    } catch (e) {
-      log.error('[MouseTracker] Failed to load macOS-specific modules. Mouse tracking on macOS will be disabled.', e)
-    }
+    // macOS uses Electron's built-in `screen.getCursorScreenPoint()` polled
+    // at MOUSE_RECORDING_FPS — no native module dependency, no Accessibility
+    // permission prompt, and works on every fresh clone without a build step.
+    // We trade per-click events for zero install friction; the cursor-zoom
+    // editor effect still works since it's position-driven. macos-cursor-manager
+    // is loaded for cursor-shape identification (independent of iohook).
+    macosCursorManager.initializeMacOSCursorManager()
+    log.info('[MouseTracker] Initialized macOS mouse tracking via Electron screen API polling.')
   }
 }
 
@@ -289,88 +289,60 @@ class WindowsMouseTracker extends EventEmitter implements IMouseTracker {
   }
 }
 
+// macOS implementation that polls Electron's `screen.getCursorScreenPoint()`
+// at MOUSE_RECORDING_FPS. This avoids the iohook-macos native module, which
+// ships broken on npm (no prebuilt, no source) and would otherwise require
+// every developer to clone and build a third-party native module from source.
+//
+// Trade-off: we get cursor *position* (the input the editor cursor-zoom
+// effect needs) but not click events. Click events would require a global
+// CGEventTap, which needs both an Accessibility permission grant *and* a
+// working native binding. If clicks become essential, swap this for a Swift
+// helper subprocess that taps CGEventTap and pipes events over stdio.
 class MacOSMouseTracker extends EventEmitter implements IMouseTracker {
   private pollIntervalId: NodeJS.Timeout | null = null
   private currentCursorName = 'arrow'
   private currentAniFrame = 0
-  private lastPosition = { x: 0, y: 0 }
 
   async start(): Promise<boolean> {
-    if (!iohook) {
-      log.error('[MouseTracker-macOS] Cannot start, iohook-macos module not loaded.')
-      return false
-    }
-
-    // Check accessibility permissions
-    const permissions = iohook.checkAccessibilityPermissions()
-    if (!permissions.hasPermissions) {
-      log.warn('[MouseTracker-macOS] Accessibility permissions not granted. Requesting...')
-      dialog.showErrorBox(
-        'Permissions Required',
-        'ScreenArc needs Accessibility permissions to track mouse clicks. Please grant access in System Settings > Privacy & Security > Accessibility, then restart the recording.',
-      )
-      iohook.requestAccessibilityPermissions()
-      return false // MODIFIED: Signal failure if permissions are not granted
-    }
-
-    iohook.enablePerformanceMode()
-    iohook.setPollingRate(1000 / MOUSE_RECORDING_FPS)
-
-    // Just update position, don't emit from here
-    iohook.on('mouseMoved', (event: any) => {
-      this.lastPosition = { x: event.x, y: event.y }
-    })
-
-    // Handle clicks separately
-    iohook.on('leftMouseDown', (event: any) => this.emitClickEvent(event, true))
-    iohook.on('rightMouseDown', (event: any) => this.emitClickEvent(event, true))
-    iohook.on('otherMouseDown', (event: any) => this.emitClickEvent(event, true))
-    iohook.on('leftMouseup', (event: any) => this.emitClickEvent(event, false))
-    iohook.on('rightMouseup', (event: any) => this.emitClickEvent(event, false))
-    iohook.on('otherMouseup', (event: any) => this.emitClickEvent(event, false))
-
-    iohook.startMonitoring()
-
-    // This poller is the SOLE source of 'move' events, ensuring a constant stream.
     this.pollIntervalId = setInterval(() => this.pollAndEmitMove(), 1000 / MOUSE_RECORDING_FPS)
-    log.info('[MouseTracker-macOS] Started.')
+    log.info('[MouseTracker-macOS] Started (Electron screen.getCursorScreenPoint polling).')
     return true
   }
 
   stop() {
     if (this.pollIntervalId) clearInterval(this.pollIntervalId)
-    if (iohook) {
-      iohook.removeAllListeners()
-      iohook.stopMonitoring()
-    }
+    this.pollIntervalId = null
     log.info('[MouseTracker-macOS] Stopped.')
   }
 
-  private emitClickEvent = (event: any, isPressed: boolean) => {
-    // A click event provides the most up-to-date cursor position.
-    this.lastPosition = { x: event.x, y: event.y }
-    // Check for cursor shape changes right before emitting the click.
-    this.updateCursorState()
-
-    const data: MetaDataItem = {
-      timestamp: Date.now(),
-      x: event.x,
-      y: event.y,
-      type: 'click',
-      cursorImageKey: `${this.currentCursorName}-${this.currentAniFrame}`,
-      button: this.mapButton(event.button),
-      pressed: isPressed,
-    }
-    this.emit('data', data)
-  }
-
   private pollAndEmitMove = () => {
+    let point: { x: number; y: number }
+    try {
+      point = screen.getCursorScreenPoint()
+    } catch (err) {
+      log.error('[MouseTracker-macOS] getCursorScreenPoint threw:', err)
+      return
+    }
+
+    // `screen.getCursorScreenPoint()` returns coordinates in DIPs (logical
+    // pixels), but `recordingGeometry` over in recording-manager.ts is in
+    // physical pixels (multiplied by display.scaleFactor). On a Retina
+    // display these differ by 2×, so without this conversion the geometry
+    // filter would reject most points and the editor would render the
+    // cursor in the wrong place. Convert here, once, in the only spot that
+    // sources DIP coordinates.
+    const display = screen.getDisplayNearestPoint(point)
+    const scale = display.scaleFactor || 1
+    const physicalX = Math.round(point.x * scale)
+    const physicalY = Math.round(point.y * scale)
+
     this.updateCursorState()
 
     const data: MetaDataItem = {
       timestamp: Date.now(),
-      x: this.lastPosition.x,
-      y: this.lastPosition.y,
+      x: physicalX,
+      y: physicalY,
       type: 'move',
       cursorImageKey: `${this.currentCursorName}-${this.currentAniFrame}`,
     }
@@ -379,23 +351,9 @@ class MacOSMouseTracker extends EventEmitter implements IMouseTracker {
 
   private updateCursorState = () => {
     this.currentCursorName = macosCursorManager.getCurrentCursorName()
-    // NOTE: Animated cursors like the spinning wheel are not currently
-    // identifiable by name with the native module being used.
-    // Therefore, animation frame calculation is not implemented for macOS.
+    // Animated cursors (spinning wheel) aren't identifiable by name with the
+    // native cursor module, so animation frame calculation stays at 0.
     this.currentAniFrame = 0
-  }
-
-  private mapButton = (code: number) => {
-    switch (code) {
-      case MOUSE_BUTTONS.MACOS.LEFT:
-        return 'left'
-      case MOUSE_BUTTONS.MACOS.RIGHT:
-        return 'right'
-      case MOUSE_BUTTONS.MACOS.MIDDLE:
-        return 'middle'
-      default:
-        return 'unknown'
-    }
   }
 }
 
@@ -416,10 +374,7 @@ export function createMouseTracker(): IMouseTracker | null {
       return new WindowsMouseTracker()
 
     case 'darwin':
-      if (!iohook) {
-        log.warn('[MouseTracker] iohook-macos not available — mouse tracking disabled (rebuild native modules to fix)')
-        return null
-      }
+      // Always available — uses Electron's built-in screen API, no native deps.
       return new MacOSMouseTracker()
     default:
       log.warn(`Mouse tracking not supported on platform: ${process.platform}`)

--- a/electron/main/features/mouse-tracker.ts
+++ b/electron/main/features/mouse-tracker.ts
@@ -417,7 +417,7 @@ export function createMouseTracker(): IMouseTracker | null {
 
     case 'darwin':
       if (!iohook) {
-        dialog.showErrorBox('Dependency Missing', 'Could not load the required module for mouse tracking on macOS.')
+        log.warn('[MouseTracker] iohook-macos not available — mouse tracking disabled (rebuild native modules to fix)')
         return null
       }
       return new MacOSMouseTracker()

--- a/electron/main/features/recording-manager.ts
+++ b/electron/main/features/recording-manager.ts
@@ -5,7 +5,7 @@ import log from 'electron-log/main'
 import { spawn } from 'node:child_process'
 import path from 'node:path'
 import fsPromises from 'node:fs/promises'
-import { app, Menu, Tray, nativeImage, screen, ipcMain, dialog, systemPreferences, desktopCapturer } from 'electron'
+import { app, Menu, Tray, nativeImage, screen, ipcMain, dialog, systemPreferences, desktopCapturer, shell } from 'electron'
 import { appState } from '../state'
 import { getFFmpegPath, ensureDirectoryExists } from '../lib/utils'
 import { VITE_PUBLIC } from '../lib/constants'
@@ -15,15 +15,24 @@ import { createEditorWindow, cleanupEditorFiles } from '../windows/editor-window
 import { createSavingWindow, createSelectionWindow } from '../windows/temporary-windows'
 import type { RecordingSession, RecordingGeometry } from '../state'
 import { SystemAudioWriter } from './system-audio-writer'
-import { buildMuxArgs } from './build-mux-args'
+import { ScreenVideoWriter } from './screen-video-writer'
+import { buildMuxArgs, buildMacMuxArgs } from './build-mux-args'
 
 const FFMPEG_PATH = getFFmpegPath()
 const SYSTEM_AUDIO_STOP_TIMEOUT_MS = 5000
+const SCREEN_CAPTURE_STOP_TIMEOUT_MS = 5000
 
-// Module-scoped writer used by the renderer-streamed system-audio capture path.
-// Lives outside appState because it's a helper, not session data.
+// Module-scoped writers used by the renderer-streamed capture paths. They
+// live outside appState because they're helpers, not session data.
 const systemAudioWriter = new SystemAudioWriter()
+const screenVideoWriter = new ScreenVideoWriter()
 let pendingSystemAudioStop:
+  | {
+      promise: Promise<void>
+      resolve: () => void
+    }
+  | null = null
+let pendingScreenCaptureStop:
   | {
       promise: Promise<void>
       resolve: () => void
@@ -34,9 +43,19 @@ export function getSystemAudioWriter(): SystemAudioWriter {
   return systemAudioWriter
 }
 
+export function getScreenVideoWriter(): ScreenVideoWriter {
+  return screenVideoWriter
+}
+
 export function markSystemAudioStopped(): void {
   pendingSystemAudioStop?.resolve()
   pendingSystemAudioStop = null
+}
+
+export function markScreenCaptureStopped(): void {
+  log.info('[ScreenCapture] Renderer acknowledged stop; resolving waiter.')
+  pendingScreenCaptureStop?.resolve()
+  pendingScreenCaptureStop = null
 }
 
 function createSystemAudioStopWaiter(): Promise<void> {
@@ -51,6 +70,20 @@ function createSystemAudioStopWaiter(): Promise<void> {
   }
 
   return pendingSystemAudioStop.promise
+}
+
+function createScreenCaptureStopWaiter(): Promise<void> {
+  if (!pendingScreenCaptureStop) {
+    let resolve!: () => void
+    pendingScreenCaptureStop = {
+      promise: new Promise<void>((res) => {
+        resolve = res
+      }),
+      resolve,
+    }
+  }
+
+  return pendingScreenCaptureStop.promise
 }
 
 async function waitForSystemAudioStop(waiter: Promise<void>): Promise<void> {
@@ -69,6 +102,25 @@ async function waitForSystemAudioStop(waiter: Promise<void>): Promise<void> {
       log.warn('[SystemAudio] Renderer did not acknowledge stop before timeout; finalizing writer anyway.')
     }
     pendingSystemAudioStop = null
+  }
+}
+
+async function waitForScreenCaptureStop(waiter: Promise<void>): Promise<void> {
+  let didAcknowledge = false
+  try {
+    await Promise.race([
+      waiter.then(() => {
+        didAcknowledge = true
+      }),
+      new Promise<void>((resolve) => {
+        setTimeout(resolve, SCREEN_CAPTURE_STOP_TIMEOUT_MS)
+      }),
+    ])
+  } finally {
+    if (!didAcknowledge) {
+      log.warn('[ScreenCapture] Renderer did not acknowledge stop before timeout; finalizing writer anyway.')
+    }
+    pendingScreenCaptureStop = null
   }
 }
 
@@ -153,10 +205,14 @@ async function validateRecordingFiles(session: RecordingSession): Promise<boolea
 
 /**
  * The core function that spawns FFmpeg and the mouse tracker to begin recording.
- * @param inputArgs - Platform-specific FFmpeg input arguments.
+ * @param inputArgs - Platform-specific FFmpeg input arguments (mic + webcam only when
+ *                    useRendererScreenCapture is true; otherwise also includes screen).
  * @param hasWebcam - Flag indicating if webcam recording is enabled.
  * @param hasMic - Flag indicating if microphone recording is enabled.
  * @param hasSystemAudio - Flag indicating if renderer-side system audio capture is enabled.
+ * @param useRendererScreenCapture - macOS only: capture screen via the renderer's
+ *                                    MediaRecorder instead of FFmpeg avfoundation.
+ *                                    avfoundation's screen input is broken on macOS 14+.
  * @param recordingGeometry - The logical dimensions and position of the recording area.
  */
 async function startActualRecording(
@@ -164,6 +220,7 @@ async function startActualRecording(
   hasWebcam: boolean,
   hasMic: boolean,
   hasSystemAudio: boolean,
+  useRendererScreenCapture: boolean,
   recordingGeometry: RecordingGeometry,
 ) {
   const recordingDir = path.join(process.env.HOME || process.env.USERPROFILE || '.', '.screenarc')
@@ -172,8 +229,35 @@ async function startActualRecording(
 
   const screenVideoPath = path.join(recordingDir, `${baseName}-screen.mp4`)
   const webcamVideoPath = hasWebcam ? path.join(recordingDir, `${baseName}-webcam.mp4`) : undefined
-  const systemAudioPath = hasSystemAudio ? path.join(recordingDir, `${baseName}-system.webm`) : undefined
   const metadataPath = path.join(recordingDir, `${baseName}.json`)
+
+  // On macOS the renderer captures the screen (and folds in optional system
+  // audio) directly into one .webm file. On other platforms FFmpeg captures
+  // the screen as before, and the renderer only delivers a separate
+  // system-audio webm when the user enabled it.
+  const screenWebmPath = useRendererScreenCapture
+    ? path.join(recordingDir, `${baseName}-screen.webm`)
+    : undefined
+  const webmHasSystemAudio = useRendererScreenCapture && hasSystemAudio
+  const systemAudioPath =
+    !useRendererScreenCapture && hasSystemAudio
+      ? path.join(recordingDir, `${baseName}-system.webm`)
+      : undefined
+  const micAudioPath =
+    useRendererScreenCapture && hasMic ? path.join(recordingDir, `${baseName}-mic.m4a`) : undefined
+
+  log.info('[RecordingManager] Resolved file paths for session:', {
+    baseName,
+    screenVideoPath,
+    screenWebmPath,
+    systemAudioPath,
+    micAudioPath,
+    webcamVideoPath,
+    useRendererScreenCapture,
+    webmHasSystemAudio,
+    hasMic,
+    hasWebcam,
+  })
 
   // Store recordingGeometry in the session
   appState.currentRecordingSession = {
@@ -181,13 +265,23 @@ async function startActualRecording(
     webcamVideoPath,
     systemAudioPath,
     hasMicAudio: hasMic,
+    screenWebmPath,
+    webmHasSystemAudio,
+    micAudioPath,
     metadataPath,
     recordingGeometry,
   }
 
   if (systemAudioPath) {
+    log.info(`[SystemAudio] Starting writer for ${systemAudioPath}`)
     markSystemAudioStopped()
     systemAudioWriter.start(systemAudioPath)
+  }
+
+  if (screenWebmPath) {
+    log.info(`[ScreenCapture] Starting writer for ${screenWebmPath}`)
+    markScreenCaptureStopped()
+    screenVideoWriter.start(screenWebmPath)
   }
 
   appState.recorderWin?.minimize()
@@ -226,32 +320,45 @@ async function startActualRecording(
     }
   }
 
-  const finalArgs = buildFfmpegArgs(inputArgs, hasWebcam, hasMic, screenVideoPath, webcamVideoPath)
-  log.info(`[FFMPEG] Starting FFmpeg with args: ${finalArgs.join(' ')}`)
-  appState.ffmpegProcess = spawn(FFMPEG_PATH, finalArgs)
+  // On macOS we may not need FFmpeg at all: if the user disabled both mic and
+  // webcam, the renderer's MediaRecorder writes the only output we need.
+  const needsFfmpeg = !useRendererScreenCapture || hasMic || hasWebcam
+  if (needsFfmpeg) {
+    const finalArgs = useRendererScreenCapture
+      ? buildMacFfmpegArgs(inputArgs, hasMic, hasWebcam, micAudioPath, webcamVideoPath)
+      : buildFfmpegArgs(inputArgs, hasWebcam, hasMic, screenVideoPath, webcamVideoPath)
+    log.info(`[FFMPEG] Starting FFmpeg with args: ${finalArgs.join(' ')}`)
+    appState.ffmpegProcess = spawn(FFMPEG_PATH, finalArgs)
 
-  // Monitor FFmpeg's stderr for progress, errors, and sync timing
-  appState.ffmpegProcess.stderr.on('data', (data: any) => {
-    const message = data.toString()
-    log.warn(`[FFMPEG stderr]: ${message}`)
+    // Monitor FFmpeg's stderr for progress, errors, and sync timing
+    appState.ffmpegProcess.stderr.on('data', (data: any) => {
+      const message = data.toString()
+      log.warn(`[FFMPEG stderr]: ${message}`)
 
-    // Early detection of fatal errors to provide immediate feedback
-    const fatalErrorKeywords = [
-      'Cannot open display',
-      'Invalid argument',
-      'Device not found',
-      'Unknown input format',
-      'error opening device',
-    ]
-    if (fatalErrorKeywords.some((keyword) => message.toLowerCase().includes(keyword.toLowerCase()))) {
-      log.error(`[FFMPEG] Fatal error detected: ${message}`)
-      dialog.showErrorBox(
-        'Recording Failed',
-        `A critical error occurred while starting the recording process:\n\n${message}\n\nPlease check your device permissions and configurations.`,
-      )
-      setTimeout(() => cleanupAndDiscard(), 100)
-    }
-  })
+      // Early detection of fatal errors to provide immediate feedback
+      const fatalErrorKeywords = [
+        'Cannot open display',
+        'Invalid argument',
+        'Device not found',
+        'Unknown input format',
+        'error opening device',
+      ]
+      if (fatalErrorKeywords.some((keyword) => message.toLowerCase().includes(keyword.toLowerCase()))) {
+        log.error(`[FFMPEG] Fatal error detected: ${message}`)
+        dialog.showErrorBox(
+          'Recording Failed',
+          `A critical error occurred while starting the recording process:\n\n${message}\n\nPlease check your device permissions and configurations.`,
+        )
+        setTimeout(() => cleanupAndDiscard(), 100)
+      }
+    })
+
+    appState.ffmpegProcess.on('exit', (code, signal) => {
+      log.info(`[FFMPEG] Process exited (code=${code}, signal=${signal}).`)
+    })
+  } else {
+    log.info('[RecordingManager] No FFmpeg process needed — screen video and audio come entirely from the renderer.')
+  }
 
   // Notify the recorder window that recording has started
   appState.recorderWin?.webContents.send('recording-started')
@@ -312,6 +419,48 @@ function buildFfmpegArgs(
 
   return finalArgs
 }
+
+/**
+ * macOS-only FFmpeg args builder. We capture the screen in the renderer (see
+ * src/lib/screen-capture.ts), so this only handles mic and/or webcam. Mic
+ * lands in its own AAC/m4a file because there's no longer a screen output to
+ * route it into; the post-recording mux folds it back in.
+ *
+ * Input order in `inputArgs` mirrors `startRecording`: mic first (if any),
+ * then webcam (if any).
+ */
+function buildMacFfmpegArgs(
+  inputArgs: string[],
+  hasMic: boolean,
+  hasWebcam: boolean,
+  micOut?: string,
+  webcamOut?: string,
+): string[] {
+  const finalArgs = [...inputArgs]
+  const micIndex = hasMic ? 0 : -1
+  const webcamIndex = hasMic ? (hasWebcam ? 1 : -1) : hasWebcam ? 0 : -1
+
+  if (hasMic && micOut) {
+    finalArgs.push('-map', `${micIndex}:a`, '-c:a', 'aac', '-b:a', '192k', micOut)
+  }
+
+  if (hasWebcam && webcamOut) {
+    finalArgs.push(
+      '-map',
+      `${webcamIndex}:v`,
+      '-c:v',
+      'libx264',
+      '-preset',
+      'ultrafast',
+      '-pix_fmt',
+      'yuv420p',
+      webcamOut,
+    )
+  }
+
+  return finalArgs
+}
+
 /**
  * Creates the system tray icon and context menu for controlling an active recording.
  */
@@ -373,7 +522,6 @@ export async function startRecording(options: any) {
         defaultId: 0,
       })
       if (response === 0) {
-        const { shell } = require('electron')
         shell.openExternal('x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture')
       }
       return { canceled: true }
@@ -480,11 +628,12 @@ export async function startRecording(options: any) {
         )
         break
       case 'darwin':
-        baseFfmpegArgs.push(
-          '-f',
-          'avfoundation',
-          '-i',
-          `${allDisplays.findIndex((d) => d.id === targetDisplay.id) || 0}:none`,
+        // macOS 14+ can no longer capture the screen via avfoundation —
+        // AVCaptureScreenInput is deprecated and returns "Input/output error".
+        // We capture the screen in the renderer (ScreenCaptureKit) instead.
+        // No FFmpeg screen input here.
+        log.info(
+          `[RecordingManager] macOS fullscreen: deferring screen capture to renderer (display.id=${targetDisplay.id}, ${safeWidth}x${safeHeight}).`,
         )
         break
     }
@@ -546,8 +695,21 @@ export async function startRecording(options: any) {
   if (process.platform === 'linux') {
     appState.originalCursorScale = await getCursorScale()
   }
-  log.info('[RecordingManager] Starting actual recording with args:', baseFfmpegArgs)
-  return startActualRecording(baseFfmpegArgs, !!webcam, !!mic, wantsSystemAudio, recordingGeometry)
+  const useRendererScreenCapture = process.platform === 'darwin'
+  log.info('[RecordingManager] Starting actual recording with args:', baseFfmpegArgs, {
+    hasWebcam: !!webcam,
+    hasMic: !!mic,
+    wantsSystemAudio,
+    useRendererScreenCapture,
+  })
+  return startActualRecording(
+    baseFfmpegArgs,
+    !!webcam,
+    !!mic,
+    wantsSystemAudio,
+    useRendererScreenCapture,
+    recordingGeometry,
+  )
 }
 
 /**
@@ -555,30 +717,55 @@ export async function startRecording(options: any) {
  */
 export async function stopRecording() {
   restoreOriginalCursorScale()
-  log.info('Stopping recording, preparing to save...')
+  log.info('[StopRecord] Stopping recording, preparing to save...')
   appState.tray?.destroy()
   appState.tray = null
   createSavingWindow()
 
   const session = appState.currentRecordingSession
+  log.info('[StopRecord] Current session:', {
+    screenVideoPath: session?.screenVideoPath,
+    screenWebmPath: session?.screenWebmPath,
+    systemAudioPath: session?.systemAudioPath,
+    micAudioPath: session?.micAudioPath,
+    webcamVideoPath: session?.webcamVideoPath,
+    webmHasSystemAudio: session?.webmHasSystemAudio,
+    hasMicAudio: session?.hasMicAudio,
+  })
   const waitForRendererSystemAudioStop = session?.systemAudioPath ? createSystemAudioStopWaiter() : null
+  const waitForRendererScreenCaptureStop = session?.screenWebmPath ? createScreenCaptureStopWaiter() : null
 
-  // Tell the renderer to stop its MediaRecorder so any pending chunks land in
-  // the writer's queue. The recorder window flushes a final chunk on stop().
+  // Tell the renderer to stop its MediaRecorder(s) so any pending chunks land
+  // in the writer's queue. The renderer flushes a final chunk on stop().
   if (waitForRendererSystemAudioStop) {
+    log.info('[StopRecord] Asking renderer to stop system-audio MediaRecorder.')
     appState.recorderWin?.webContents.send('recorder:stop-system-audio')
+  }
+  if (waitForRendererScreenCaptureStop) {
+    log.info('[StopRecord] Asking renderer to stop screen-capture MediaRecorder.')
+    appState.recorderWin?.webContents.send('recorder:stop-screen-capture')
   }
 
   // Step 1: Wait for FFmpeg and tracker to finish
   await cleanupAndSave()
-  log.info('FFmpeg process finished and file is finalized.')
+  log.info('[StopRecord] FFmpeg process finished and file is finalized (or never spawned).')
 
   // Step 1b: Wait for the renderer to finish forwarding the tail chunk, then
-  // flush and finalize the system-audio file (no-op when not used).
+  // flush and finalize the renderer-side files (no-op when not used).
   if (waitForRendererSystemAudioStop) {
     await waitForSystemAudioStop(waitForRendererSystemAudioStop)
   }
   await systemAudioWriter.finalize()
+
+  if (waitForRendererScreenCaptureStop) {
+    await waitForScreenCaptureStop(waitForRendererScreenCaptureStop)
+  }
+  try {
+    await screenVideoWriter.finalize()
+    log.info('[StopRecord] Screen-capture writer finalized successfully.')
+  } catch (err) {
+    log.error('[StopRecord] Screen-capture writer failed during finalize:', err)
+  }
 
   const finalizedSession = appState.currentRecordingSession
   if (!finalizedSession) {
@@ -591,10 +778,25 @@ export async function stopRecording() {
   // Notify recorder window that the recording has finished, allowing it to reset its UI
   appState.recorderWin?.webContents.send('recording-finished', { canceled: false, ...finalizedSession })
 
-  // Step 2: Process and save metadata (after video file is complete)
+  // Step 2a: macOS — mux the renderer WebM (with optional system audio + mic)
+  // into the final .mp4 BEFORE metadata processing so processAndSaveMetadata
+  // can stat() the final file.
+  if (finalizedSession.screenWebmPath) {
+    try {
+      await muxMacScreenWebm(finalizedSession)
+    } catch (err) {
+      log.error('[StopRecord] macOS mux failed. The screen webm will be kept for inspection.', err)
+      // Leave artifacts in place so the user can recover. Validation will
+      // fail below and the user gets a clear error.
+    }
+  }
+
+  // Step 2b: Process and save metadata (after video file is complete)
   await processAndSaveMetadata(finalizedSession)
 
-  // Step 2b: If we captured system audio, mux it into the screen file.
+  // Step 2c: Linux/Windows — if we captured system audio separately, mux it
+  // into the (already-existing) screen mp4. Skipped on macOS because the
+  // system audio is already inside the webm and folded in by muxMacScreenWebm.
   if (finalizedSession.systemAudioPath) {
     try {
       await muxSystemAudio(finalizedSession)
@@ -709,6 +911,110 @@ async function muxSystemAudio(session: RecordingSession): Promise<void> {
 }
 
 /**
+ * macOS only: transcodes the renderer-recorded screen WebM (VP9 + optional
+ * Opus) into the final screen MP4 (H.264 + AAC), folding in the optional mic
+ * AAC track produced by FFmpeg. After this returns successfully:
+ *   - session.screenVideoPath has been (re)created with the muxed MP4
+ *   - session.screenWebmPath / micAudioPath have been deleted and cleared
+ *   - session.systemAudioPath stays unset (system audio rode inside the webm)
+ */
+async function muxMacScreenWebm(session: RecordingSession): Promise<void> {
+  if (!session.screenWebmPath) return
+
+  // Confirm the webm exists and is non-empty before launching ffmpeg.
+  let webmStat
+  try {
+    webmStat = await fsPromises.stat(session.screenWebmPath)
+  } catch (err) {
+    log.error(
+      '[MacMux] Screen webm missing — renderer never produced output. Cannot proceed.',
+      err,
+    )
+    throw new Error('Screen recording produced no output (renderer did not write any chunks).')
+  }
+  if (webmStat.size === 0) {
+    log.error('[MacMux] Screen webm is empty (zero bytes). Aborting mux.')
+    throw new Error('Screen recording produced an empty file.')
+  }
+  log.info(`[MacMux] Screen webm size: ${webmStat.size} bytes (${session.screenWebmPath}).`)
+
+  // Validate optional mic input. Drop a missing/empty mic file silently —
+  // the recording is still useful with just the video (and possibly system
+  // audio inside the webm).
+  let resolvedMicPath = session.micAudioPath
+  if (resolvedMicPath) {
+    try {
+      const micStat = await fsPromises.stat(resolvedMicPath)
+      if (micStat.size === 0) {
+        log.warn('[MacMux] Mic file is empty; dropping mic from mux.')
+        resolvedMicPath = undefined
+      } else {
+        log.info(`[MacMux] Mic file size: ${micStat.size} bytes (${resolvedMicPath}).`)
+      }
+    } catch (err) {
+      log.warn('[MacMux] Mic file missing; dropping mic from mux.', err)
+      resolvedMicPath = undefined
+    }
+  }
+
+  const args = buildMacMuxArgs({
+    screenWebmInput: session.screenWebmPath,
+    micAudioInput: resolvedMicPath,
+    output: session.screenVideoPath,
+    webmHasSystemAudio: !!session.webmHasSystemAudio,
+  })
+  log.info(`[MacMux] Running ffmpeg ${args.join(' ')}`)
+
+  await new Promise<void>((resolve, reject) => {
+    const proc = spawn(FFMPEG_PATH, args)
+    let stderr = ''
+    proc.stderr.on('data', (d) => {
+      stderr += d.toString()
+    })
+    proc.on('error', (err) => {
+      log.error('[MacMux] ffmpeg spawn error:', err)
+      reject(err)
+    })
+    proc.on('close', (code) => {
+      if (code === 0) {
+        log.info('[MacMux] ffmpeg mux exited 0 — final mp4 is ready.')
+        resolve()
+      } else {
+        log.error(`[MacMux] ffmpeg exited ${code}: ${stderr.slice(-2000)}`)
+        reject(new Error(`ffmpeg mac mux exited ${code}: ${stderr.slice(-500)}`))
+      }
+    })
+  })
+
+  // Confirm output exists and isn't empty before cleaning up sources.
+  try {
+    const outStat = await fsPromises.stat(session.screenVideoPath)
+    log.info(`[MacMux] Final mp4 size: ${outStat.size} bytes (${session.screenVideoPath}).`)
+    if (outStat.size === 0) {
+      throw new Error('Mux produced empty output file.')
+    }
+  } catch (err) {
+    log.error('[MacMux] Could not stat output mp4 after mux:', err)
+    throw err
+  }
+
+  // Tidy up source files. We only delete after we've confirmed the mp4 is
+  // good, so a half-broken mux still leaves the user's data on disk.
+  await fsPromises.unlink(session.screenWebmPath).catch((err) => {
+    log.warn('[MacMux] Failed to delete screen webm after mux.', err)
+  })
+  if (session.micAudioPath) {
+    await fsPromises.unlink(session.micAudioPath).catch((err) => {
+      log.warn('[MacMux] Failed to delete mic m4a after mux.', err)
+    })
+  }
+  session.screenWebmPath = undefined
+  session.micAudioPath = undefined
+  session.webmHasSystemAudio = false
+  log.info('[MacMux] Cleanup complete.')
+}
+
+/**
  * Cancels the recording and discards all associated files and processes.
  */
 export async function cancelRecording() {
@@ -806,16 +1112,18 @@ export async function cleanupAndDiscard() {
   if (!appState.currentRecordingSession) return
   log.warn('[Cleanup] Discarding current recording session.')
   markSystemAudioStopped()
+  markScreenCaptureStopped()
   const sessionToDiscard = { ...appState.currentRecordingSession }
   appState.currentRecordingSession = null
 
   appState.ffmpegProcess?.kill('SIGKILL')
   appState.ffmpegProcess = null
 
-  // Tell the renderer to stop its MediaRecorder; even if it ignores us,
-  // aborting the writer means subsequent IPC chunks are no-ops.
+  // Tell the renderer to stop its MediaRecorder(s); even if it ignores us,
+  // aborting the writers means subsequent IPC chunks are no-ops.
   appState.recorderWin?.webContents.send('recorder:stop-system-audio')
-  await systemAudioWriter.abort()
+  appState.recorderWin?.webContents.send('recorder:stop-screen-capture')
+  await Promise.allSettled([systemAudioWriter.abort(), screenVideoWriter.abort()])
 
   appState.mouseTracker?.stop()
   appState.mouseTracker = null
@@ -832,6 +1140,12 @@ export async function cleanupAndDiscard() {
     await cleanupEditorFiles(sessionToDiscard)
     if (sessionToDiscard.systemAudioPath) {
       await fsPromises.unlink(sessionToDiscard.systemAudioPath).catch(() => {})
+    }
+    if (sessionToDiscard.screenWebmPath) {
+      await fsPromises.unlink(sessionToDiscard.screenWebmPath).catch(() => {})
+    }
+    if (sessionToDiscard.micAudioPath) {
+      await fsPromises.unlink(sessionToDiscard.micAudioPath).catch(() => {})
     }
   }, 200)
 }
@@ -854,7 +1168,7 @@ export async function cleanupOrphanedRecordings() {
 
   try {
     const allFiles = await fsPromises.readdir(recordingDir)
-    const filePattern = /^ScreenArc-recording-\d+(-screen\.mp4|-screen\.muxed\.mp4|-webcam\.mp4|-system\.webm|\.json)$/
+    const filePattern = /^ScreenArc-recording-\d+(-screen\.mp4|-screen\.muxed\.mp4|-screen\.webm|-webcam\.mp4|-system\.webm|-mic\.m4a|\.json)$/
     const filesToDelete = allFiles
       .filter((file) => filePattern.test(file))
       .map((file) => path.join(recordingDir, file))

--- a/electron/main/features/recording-manager.ts
+++ b/electron/main/features/recording-manager.ts
@@ -5,7 +5,7 @@ import log from 'electron-log/main'
 import { spawn } from 'node:child_process'
 import path from 'node:path'
 import fsPromises from 'node:fs/promises'
-import { app, Menu, Tray, nativeImage, screen, ipcMain, dialog, systemPreferences } from 'electron'
+import { app, Menu, Tray, nativeImage, screen, ipcMain, dialog, systemPreferences, desktopCapturer } from 'electron'
 import { appState } from '../state'
 import { getFFmpegPath, ensureDirectoryExists } from '../lib/utils'
 import { VITE_PUBLIC } from '../lib/constants'
@@ -352,22 +352,30 @@ export async function startRecording(options: any) {
   // macOS Permissions Check
   if (process.platform === 'darwin') {
     // 1. Check Screen Recording Permissions
-    let screenAccess = systemPreferences.getMediaAccessStatus('screen')
-    if (screenAccess === 'not-determined') {
-      try {
-        // eslint-disable-next-line @typescript-eslint/no-var-requires
-        const iohook = require('iohook-macos')
-        const permissions = iohook.checkAccessibilityPermissions()
-        screenAccess = permissions.hasPermissions ? 'granted' : 'denied'
-      } catch (e) {
-        log.error('[MouseTracker] Failed to load macOS-specific modules. Mouse tracking on macOS will be disabled.', e)
-      }
+    // getMediaAccessStatus('screen') is unreliable on macOS 14+ (Sonoma/Sequoia)
+    // — always returns 'granted'. Probe via desktopCapturer instead: permission
+    // denied → empty sources array.
+    let screenGranted = false
+    try {
+      const sources = await desktopCapturer.getSources({ types: ['screen'], thumbnailSize: { width: 1, height: 1 } })
+      screenGranted = sources.length > 0
+    } catch (e) {
+      log.warn('[Permission] desktopCapturer.getSources failed:', e)
     }
-    if (screenAccess !== 'granted') {
-      dialog.showErrorBox(
-        'Screen Recording Permission Required',
-        'Accessibility permissions required. Please go to System Preferences > Security & Privacy > Privacy > Accessibility and enable this application.',
-      )
+    if (!screenGranted) {
+      const { response } = await dialog.showMessageBox({
+        type: 'warning',
+        title: 'Screen Recording Permission Required',
+        message: 'ScreenArc needs Screen Recording permission to record your screen.',
+        detail:
+          'Go to System Settings → Privacy & Security → Screen Recording and enable the toggle next to "Electron" (the dev build). Then restart the app and try again.',
+        buttons: ['Open System Settings', 'Cancel'],
+        defaultId: 0,
+      })
+      if (response === 0) {
+        const { shell } = require('electron')
+        shell.openExternal('x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture')
+      }
       return { canceled: true }
     }
 
@@ -633,6 +641,17 @@ export async function stopRecording() {
 async function muxSystemAudio(session: RecordingSession): Promise<void> {
   if (!session.systemAudioPath) return
 
+  // If the screen file wasn't created (e.g. avfoundation permission failure),
+  // there is nothing to mux into — clean up and bail.
+  try {
+    await fsPromises.stat(session.screenVideoPath)
+  } catch {
+    log.warn('[Mux] Screen file missing; skipping mux and discarding system audio.')
+    await fsPromises.unlink(session.systemAudioPath).catch(() => {})
+    session.systemAudioPath = undefined
+    return
+  }
+
   // Validate inputs exist and have content. A zero-byte system-audio file
   // means the renderer never delivered chunks (e.g., permission denied) —
   // skip the mux and proceed with the original screen file.
@@ -712,6 +731,13 @@ async function cleanupAndSave(): Promise<void> {
     if (appState.ffmpegProcess) {
       const ffmpeg = appState.ffmpegProcess
       appState.ffmpegProcess = null
+      // Process may have already exited (e.g., avfoundation I/O error); if so,
+      // exitCode is set and the 'close' event will never fire again.
+      if (ffmpeg.exitCode !== null || ffmpeg.killed) {
+        log.info(`FFmpeg process already exited with code ${ffmpeg.exitCode}`)
+        resolve()
+        return
+      }
       ffmpeg.on('close', (code: any) => {
         log.info(`FFmpeg process exited with code ${code}`)
         resolve()

--- a/electron/main/features/screen-video-writer.test.ts
+++ b/electron/main/features/screen-video-writer.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+
+import { ScreenVideoWriter } from './screen-video-writer'
+
+let scratchDir: string
+
+beforeEach(() => {
+  scratchDir = mkdtempSync(path.join(tmpdir(), 'screenarc-svw-'))
+})
+
+afterEach(async () => {
+  await new Promise((resolve) => setTimeout(resolve, 0))
+  rmSync(scratchDir, { recursive: true, force: true })
+})
+
+const filePath = () => path.join(scratchDir, 'screen.webm')
+
+describe('ScreenVideoWriter', () => {
+  test('write() before start() is a safe no-op and reports zero bytes', async () => {
+    const writer = new ScreenVideoWriter()
+    const total = await writer.write(Buffer.from([1, 2, 3]))
+    expect(total).toBe(0)
+  })
+
+  test('start() then write() persists bytes to disk and returns running total', async () => {
+    const writer = new ScreenVideoWriter()
+    writer.start(filePath())
+
+    const first = await writer.write(Buffer.from([1, 2, 3]))
+    const second = await writer.write(Buffer.from([4, 5]))
+
+    expect(first).toBe(3)
+    expect(second).toBe(5)
+
+    await writer.finalize()
+    const onDisk = readFileSync(filePath())
+    expect(Array.from(onDisk)).toEqual([1, 2, 3, 4, 5])
+  })
+
+  test('concurrent writes are serialized in submission order', async () => {
+    const writer = new ScreenVideoWriter()
+    writer.start(filePath())
+
+    const writes = [
+      writer.write(Buffer.from([0xa])),
+      writer.write(Buffer.from([0xb])),
+      writer.write(Buffer.from([0xc])),
+      writer.write(Buffer.from([0xd])),
+      writer.write(Buffer.from([0xe])),
+    ]
+
+    const totals = await Promise.all(writes)
+    expect(totals).toEqual([1, 2, 3, 4, 5])
+
+    await writer.finalize()
+    const onDisk = readFileSync(filePath())
+    expect(Array.from(onDisk)).toEqual([0xa, 0xb, 0xc, 0xd, 0xe])
+  })
+
+  test('finalize() flushes pending writes before resolving', async () => {
+    const writer = new ScreenVideoWriter()
+    writer.start(filePath())
+
+    writer.write(Buffer.from([1, 2]))
+    writer.write(Buffer.from([3, 4]))
+    await writer.finalize()
+
+    const onDisk = readFileSync(filePath())
+    expect(Array.from(onDisk)).toEqual([1, 2, 3, 4])
+  })
+
+  test('write() after finalize() is a safe no-op', async () => {
+    const writer = new ScreenVideoWriter()
+    writer.start(filePath())
+    await writer.write(Buffer.from([1]))
+    await writer.finalize()
+
+    const total = await writer.write(Buffer.from([2, 3]))
+    expect(total).toBe(1)
+
+    const onDisk = readFileSync(filePath())
+    expect(Array.from(onDisk)).toEqual([1])
+  })
+
+  test('abort() prevents further writes from persisting', async () => {
+    const writer = new ScreenVideoWriter()
+    writer.start(filePath())
+    const beforeAbort = await writer.write(Buffer.from([1, 2]))
+    await writer.abort()
+
+    const afterAbort = await writer.write(Buffer.from([3, 4]))
+    expect(beforeAbort).toBe(2)
+    expect(afterAbort).toBe(2)
+  })
+
+  test('start() can begin a fresh session after finalize()', async () => {
+    const writer = new ScreenVideoWriter()
+    const firstPath = path.join(scratchDir, 'a.webm')
+    const secondPath = path.join(scratchDir, 'b.webm')
+
+    writer.start(firstPath)
+    await writer.write(Buffer.from([0x1, 0x2]))
+    await writer.finalize()
+
+    writer.start(secondPath)
+    const total = await writer.write(Buffer.from([0x9]))
+    await writer.finalize()
+
+    expect(total).toBe(1)
+    expect(Array.from(readFileSync(firstPath))).toEqual([1, 2])
+    expect(Array.from(readFileSync(secondPath))).toEqual([0x9])
+  })
+
+  test('start() creates parent directory if missing', async () => {
+    const writer = new ScreenVideoWriter()
+    const nested = path.join(scratchDir, 'nested', 'deep', 'screen.webm')
+
+    writer.start(nested)
+    await writer.write(Buffer.from([7]))
+    await writer.finalize()
+
+    expect(Array.from(readFileSync(nested))).toEqual([7])
+  })
+
+  test('start() rejects when a previous session is still active', async () => {
+    const writer = new ScreenVideoWriter()
+    writer.start(filePath())
+
+    expect(() => writer.start(path.join(scratchDir, 'other.webm'))).toThrow('still active')
+
+    await writer.abort()
+  })
+})

--- a/electron/main/features/screen-video-writer.ts
+++ b/electron/main/features/screen-video-writer.ts
@@ -1,0 +1,137 @@
+// Streams renderer-recorded screen video chunks (WebM/VP9+Opus) to disk.
+// Mirrors SystemAudioWriter; serializes appends so concurrent IPC chunks
+// never interleave inside the WebM container.
+//
+// We keep this as a separate class rather than reusing SystemAudioWriter so a
+// single recording session can hold both writers concurrently without sharing
+// state.
+
+import log from 'electron-log/main'
+import { createWriteStream, mkdirSync, type WriteStream } from 'node:fs'
+import path from 'node:path'
+import { finished } from 'node:stream/promises'
+
+export class ScreenVideoWriter {
+  private stream: WriteStream | null = null
+  private queue: Promise<void> = Promise.resolve()
+  private bytes = 0
+  private ended = false
+  private failure: Error | null = null
+  private detachStreamErrorListener: (() => void) | null = null
+
+  start(filePath: string): void {
+    if (this.stream) {
+      throw new Error('ScreenVideoWriter.start() called while a previous session is still active')
+    }
+
+    mkdirSync(path.dirname(filePath), { recursive: true })
+
+    const stream = createWriteStream(filePath, { flags: 'w' })
+    const onError = (err: Error) => {
+      if (!this.failure) {
+        this.failure = err
+        log.error('[ScreenVideoWriter] Stream error:', err)
+      }
+    }
+    stream.on('error', onError)
+
+    this.stream = stream
+    this.detachStreamErrorListener = () => {
+      stream.off('error', onError)
+    }
+    this.queue = Promise.resolve()
+    this.bytes = 0
+    this.ended = false
+    this.failure = null
+  }
+
+  async write(chunk: Buffer): Promise<number> {
+    if (this.failure) {
+      throw this.failure
+    }
+
+    const stream = this.stream
+    if (!stream || this.ended || stream.writableEnded || stream.destroyed) {
+      return this.bytes
+    }
+
+    const writeTask = this.queue.then(
+      () =>
+        new Promise<void>((resolve, reject) => {
+          if (this.failure) {
+            reject(this.failure)
+            return
+          }
+
+          if (!this.stream || this.stream !== stream || this.stream.writableEnded || this.stream.destroyed) {
+            resolve()
+            return
+          }
+
+          this.stream.write(chunk, (err) => {
+            if (err) {
+              const writeError = err instanceof Error ? err : new Error(String(err))
+              if (!this.failure) {
+                this.failure = writeError
+                log.error('[ScreenVideoWriter] Write error:', writeError)
+              }
+              reject(writeError)
+              return
+            }
+
+            this.bytes += chunk.length
+            resolve()
+          })
+        }),
+    )
+
+    this.queue = writeTask
+    await writeTask
+    return this.bytes
+  }
+
+  async finalize(): Promise<void> {
+    const stream = this.stream
+    if (!stream) return
+
+    this.ended = true
+    try {
+      await this.queue
+      if (this.failure) {
+        throw this.failure
+      }
+
+      if (!stream.writableEnded && !stream.destroyed) {
+        stream.end()
+        await finished(stream)
+      }
+    } catch (error) {
+      if (!stream.destroyed) {
+        stream.destroy()
+        await finished(stream).catch(() => {})
+      }
+      throw error
+    } finally {
+      this.reset()
+    }
+  }
+
+  async abort(): Promise<void> {
+    const stream = this.stream
+    if (!stream) return
+
+    this.ended = true
+    try {
+      stream.destroy()
+      await this.queue.catch(() => {})
+    } finally {
+      this.reset()
+    }
+  }
+
+  private reset(): void {
+    this.detachStreamErrorListener?.()
+    this.detachStreamErrorListener = null
+    this.stream = null
+  }
+}

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -1,6 +1,6 @@
 // Entry point of the Electron application.
 
-import { app, BrowserWindow, protocol, ProtocolRequest, ProtocolResponse, Menu, screen, dialog } from 'electron'
+import { app, BrowserWindow, protocol, ProtocolRequest, ProtocolResponse, Menu, screen, dialog, desktopCapturer, systemPreferences, shell } from 'electron'
 import { initMain as initAudioLoopback } from 'electron-audio-loopback'
 import log from 'electron-log/main'
 import path from 'node:path'
@@ -98,6 +98,15 @@ app.whenReady().then(async () => {
 
   // Initialize platform-specific dependencies asynchronously
   initializeMouseTrackerDependencies()
+
+  // Proactively register this app with macOS Screen Recording TCC so it
+  // appears in System Settings → Privacy & Security → Screen Recording.
+  // This must run after the window is ready.
+  if (process.platform === 'darwin') {
+    desktopCapturer.getSources({ types: ['screen'] }).catch((e) => {
+      log.warn('[Permission] desktopCapturer.getSources failed at startup:', e)
+    })
+  }
 
   // Register custom protocol for media files
   protocol.registerFileProtocol(

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -1,6 +1,6 @@
 // Entry point of the Electron application.
 
-import { app, BrowserWindow, protocol, ProtocolRequest, ProtocolResponse, Menu, screen, dialog, desktopCapturer, systemPreferences, shell } from 'electron'
+import { app, BrowserWindow, protocol, ProtocolRequest, ProtocolResponse, Menu, screen, dialog, desktopCapturer } from 'electron'
 import { initMain as initAudioLoopback } from 'electron-audio-loopback'
 import log from 'electron-log/main'
 import path from 'node:path'

--- a/electron/main/ipc/handlers/desktop.ts
+++ b/electron/main/ipc/handlers/desktop.ts
@@ -1,6 +1,6 @@
 // Handlers for desktop-related IPC (displays, sources, cursor).
 
-import { IpcMainEvent, IpcMainInvokeEvent, screen, dialog, app } from 'electron'
+import { IpcMainEvent, IpcMainInvokeEvent, screen, dialog, app, systemPreferences, shell, desktopCapturer } from 'electron'
 import { exec } from 'node:child_process'
 import log from 'electron-log/main'
 import fs from 'node:fs/promises'
@@ -44,6 +44,45 @@ export function handleSetCursorScale(_event: IpcMainEvent, scale: number) {
 
 export function showSaveDialog(_event: IpcMainInvokeEvent, options: Electron.SaveDialogOptions) {
   return dialog.showSaveDialog(options)
+}
+
+export function showMessageBox(_event: IpcMainInvokeEvent, options: Electron.MessageBoxOptions) {
+  return dialog.showMessageBox(options)
+}
+
+export async function checkScreenRecordingPermission(_event: IpcMainInvokeEvent): Promise<'granted' | 'denied' | 'not-determined'> {
+  if (process.platform !== 'darwin') return 'granted'
+
+  // getMediaAccessStatus('screen') is unreliable on macOS 14+ (always returns
+  // 'granted'). Instead, probe with desktopCapturer: if permission is denied,
+  // getSources() returns an empty array on Sequoia.
+  let hasPermission = false
+  try {
+    const sources = await desktopCapturer.getSources({ types: ['screen'], thumbnailSize: { width: 1, height: 1 } })
+    log.info('[Permission] desktopCapturer returned', sources.length, 'sources:', sources.map(s => s.name))
+    hasPermission = sources.length > 0
+  } catch (e) {
+    log.warn('[Permission] desktopCapturer.getSources threw:', e)
+    hasPermission = false
+  }
+  log.info('[Permission] screen recording hasPermission:', hasPermission)
+
+  if (!hasPermission) {
+    const { response } = await dialog.showMessageBox({
+      type: 'warning',
+      title: 'Screen Recording Permission Required',
+      message: 'ScreenArc needs Screen Recording permission to capture system audio.',
+      detail: 'Click "Open Settings" to go to System Settings → Privacy & Security → Screen Recording and enable "Electron". Then restart the app and try again.',
+      buttons: ['Open Settings', 'Cancel'],
+      defaultId: 0,
+    })
+    if (response === 0) {
+      shell.openExternal('x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture')
+    }
+    return 'denied'
+  }
+
+  return 'granted'
 }
 
 export async function getVideoFrame(

--- a/electron/main/ipc/handlers/desktop.ts
+++ b/electron/main/ipc/handlers/desktop.ts
@@ -1,6 +1,6 @@
 // Handlers for desktop-related IPC (displays, sources, cursor).
 
-import { IpcMainEvent, IpcMainInvokeEvent, screen, dialog, app, systemPreferences, shell, desktopCapturer } from 'electron'
+import { IpcMainEvent, IpcMainInvokeEvent, screen, dialog, app, shell, desktopCapturer } from 'electron'
 import { exec } from 'node:child_process'
 import log from 'electron-log/main'
 import fs from 'node:fs/promises'

--- a/electron/main/ipc/handlers/recording.ts
+++ b/electron/main/ipc/handlers/recording.ts
@@ -1,12 +1,21 @@
 // Handlers for recording-related IPC (recording).
 
+import { desktopCapturer } from 'electron'
 import {
   startRecording,
   loadVideoFromFile,
   stopRecording,
   getSystemAudioWriter,
+  getScreenVideoWriter,
   markSystemAudioStopped,
+  markScreenCaptureStopped,
 } from '../../features/recording-manager'
+
+export interface ScreenSourceInfo {
+  id: string
+  name: string
+  display_id: string
+}
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function handleStartRecording(_event: any, options: any) {
@@ -35,4 +44,34 @@ export async function handleWriteSystemAudioChunk(_event: unknown, chunk: ArrayB
 
 export function handleSystemAudioStopped(): void {
   markSystemAudioStopped()
+}
+
+/**
+ * macOS only: receives a chunk of renderer-recorded screen video (WebM
+ * cluster) from the renderer's MediaRecorder and appends it to the on-disk
+ * file. Same idempotency contract as the system-audio variant.
+ */
+export async function handleWriteScreenVideoChunk(_event: unknown, chunk: ArrayBuffer): Promise<number> {
+  if (!(chunk instanceof ArrayBuffer)) {
+    throw new Error('writeScreenVideoChunk: payload must be an ArrayBuffer')
+  }
+  return getScreenVideoWriter().write(Buffer.from(chunk))
+}
+
+export function handleScreenCaptureStopped(): void {
+  markScreenCaptureStopped()
+}
+
+/**
+ * macOS only: returns the list of available screen sources so the renderer
+ * can resolve a chosen display.id to a chromeMediaSourceId for getUserMedia.
+ * Bypasses the standard display picker — we already know which display the
+ * user selected in the recorder UI.
+ */
+export async function handleGetScreenSources(): Promise<ScreenSourceInfo[]> {
+  const sources = await desktopCapturer.getSources({
+    types: ['screen'],
+    thumbnailSize: { width: 1, height: 1 },
+  })
+  return sources.map((s) => ({ id: s.id, name: s.name, display_id: s.display_id }))
 }

--- a/electron/main/ipc/index.ts
+++ b/electron/main/ipc/index.ts
@@ -24,6 +24,8 @@ export function registerIpcHandlers() {
   ipcMain.handle('desktop:get-cursor-scale', desktopHandlers.handleGetCursorScale)
   ipcMain.on('desktop:set-cursor-scale', desktopHandlers.handleSetCursorScale)
   ipcMain.handle('dialog:showSaveDialog', desktopHandlers.showSaveDialog)
+  ipcMain.handle('dialog:showMessageBox', desktopHandlers.showMessageBox)
+  ipcMain.handle('permission:check-screen-recording', desktopHandlers.checkScreenRecordingPermission)
   ipcMain.handle('video:get-frame', desktopHandlers.getVideoFrame)
 
   ipcMain.handle('desktop:get-cursor-themes', desktopHandlers.getCursorThemes)

--- a/electron/main/ipc/index.ts
+++ b/electron/main/ipc/index.ts
@@ -38,6 +38,9 @@ export function registerIpcHandlers() {
   ipcMain.handle('recording:load-from-file', recordingHandlers.handleLoadVideoFromFile)
   ipcMain.handle('recording:write-system-audio', recordingHandlers.handleWriteSystemAudioChunk)
   ipcMain.handle('recording:system-audio-stopped', recordingHandlers.handleSystemAudioStopped)
+  ipcMain.handle('recording:write-screen-video', recordingHandlers.handleWriteScreenVideoChunk)
+  ipcMain.handle('recording:screen-capture-stopped', recordingHandlers.handleScreenCaptureStopped)
+  ipcMain.handle('recording:get-screen-sources', recordingHandlers.handleGetScreenSources)
 
   // Export
   ipcMain.handle('export:start', exportHandlers.handleStartExport)

--- a/electron/main/lib/macos-cursor-manager.ts
+++ b/electron/main/lib/macos-cursor-manager.ts
@@ -10,6 +10,12 @@ const hash = (buffer: Buffer) => createHash('sha1').update(buffer).digest('hex')
 let nativeModule: any
 const hashToNameMap: Record<string, string> = {}
 let isInitialized = false
+// Native API stops working ~immediately on Electron 31 (the prebuilt .node is
+// built against an older Node-API that returned external buffers, which
+// newer V8/Node forbids). Once we see one failure on a hot path, we latch
+// this flag and stop hammering the native binding — otherwise we'd log a
+// stack trace 60× per second for every recording.
+let runtimeUnavailable = false
 
 // These IDs are standard macOS cursor identifiers.
 const CURSOR_NAMES = ['arrow', 'IBeam', 'crosshair', 'closedHand', 'openHand', 'pointingHand']
@@ -17,27 +23,40 @@ const CURSOR_NAMES = ['arrow', 'IBeam', 'crosshair', 'closedHand', 'openHand', '
 export function initializeMacOSCursorManager() {
   try {
     nativeModule = require('node-macos-cursor')
-    isInitialized = true
 
     for (const name of CURSOR_NAMES) {
       const imageBuffer = nativeModule.getCursorPNGByName(name)
       const imageKey = hash(imageBuffer)
       hashToNameMap[imageKey] = name
     }
+    isInitialized = true
     log.info('[MacOSCursorManager] Initialized successfully with macos-cursor-manager and created image map.')
   } catch (e) {
-    log.error('[MacOSCursorManager] Failed to initialize:', e)
+    isInitialized = false
+    runtimeUnavailable = true
+    log.warn(
+      '[MacOSCursorManager] Native module unavailable on this Electron build — cursor-shape detection disabled (defaulting to "arrow"). This is non-fatal; cursor position tracking still works.',
+      e instanceof Error ? e.message : e,
+    )
   }
 }
 
 export function getCurrentCursorName(): string {
-  if (!isInitialized) return 'arrow'
+  if (!isInitialized || runtimeUnavailable) return 'arrow'
   try {
     const imageBuffer = nativeModule.getCurrentCursorPNG()
     const imageKey = hash(imageBuffer)
     return hashToNameMap[imageKey] || 'arrow'
   } catch (e) {
-    log.warn('[MacOSCursorManager] Could not get current cursor image:', e)
+    // Latch the failure so we don't spam the log on every poll. The first
+    // error message is preserved; subsequent polls just return 'arrow'.
+    if (!runtimeUnavailable) {
+      runtimeUnavailable = true
+      log.warn(
+        '[MacOSCursorManager] Native cursor lookup failed; latching off for the rest of this session:',
+        e instanceof Error ? e.message : e,
+      )
+    }
     return 'arrow'
   }
 }

--- a/electron/main/state.ts
+++ b/electron/main/state.ts
@@ -19,9 +19,22 @@ export interface RecordingSession {
   webcamVideoPath?: string
   // Set when system-audio capture (renderer-side MediaRecorder) is enabled.
   // Cleared after the post-recording mux merges it into the screen file.
+  // On macOS the system audio is folded into screenWebmPath instead, so this
+  // stays unset there.
   systemAudioPath?: string
   // True when mic capture is enabled for this session. Drives mux filter graph.
   hasMicAudio?: boolean
+  // macOS only: renderer-recorded screen video (WebM/VP9), optionally with an
+  // Opus loopback audio track when the user enabled system audio. Cleared
+  // after the post-recording mux transcodes it into screenVideoPath (.mp4).
+  screenWebmPath?: string
+  // True when screenWebmPath contains a system-audio track (renderer added a
+  // loopback audio track to the MediaRecorder stream). Drives mux filter graph.
+  webmHasSystemAudio?: boolean
+  // macOS only: separate AAC/m4a file produced by FFmpeg when only mic capture
+  // is requested (since FFmpeg no longer captures the screen there). Cleared
+  // after mux folds it into screenVideoPath.
+  micAudioPath?: string
   recordingGeometry: RecordingGeometry
 }
 

--- a/electron/main/windows/editor-window.ts
+++ b/electron/main/windows/editor-window.ts
@@ -131,9 +131,18 @@ export async function cleanupEditorFiles(files: {
   metadataPath: string
   webcamVideoPath?: string
   systemAudioPath?: string
+  screenWebmPath?: string
+  micAudioPath?: string
 }) {
   log.info('[EditorWindow] Cleaning up session files:', files)
-  const unlinkPromises = [files.screenVideoPath, files.webcamVideoPath, files.metadataPath, files.systemAudioPath]
+  const unlinkPromises = [
+    files.screenVideoPath,
+    files.webcamVideoPath,
+    files.metadataPath,
+    files.systemAudioPath,
+    files.screenWebmPath,
+    files.micAudioPath,
+  ]
     .filter(Boolean)
     .map((filePath) => (fsSync.existsSync(filePath!) ? fs.unlink(filePath!) : Promise.resolve()))
   try {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -165,6 +165,14 @@ export const electronAPI = {
     return ipcRenderer.invoke('dialog:showSaveDialog', options)
   },
 
+  showMessageBox: (options: Electron.MessageBoxOptions): Promise<Electron.MessageBoxReturnValue> => {
+    return ipcRenderer.invoke('dialog:showMessageBox', options)
+  },
+
+  checkScreenRecordingPermission: (): Promise<'granted' | 'denied' | 'not-determined'> => {
+    return ipcRenderer.invoke('permission:check-screen-recording')
+  },
+
   showItemInFolder: (path: string): void => ipcRenderer.send('shell:showItemInFolder', path),
 
   onUpdateAvailable: (callback: (info: UpdateInfo) => void) => {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -106,6 +106,22 @@ export const electronAPI = {
     return () => ipcRenderer.removeListener('recorder:stop-system-audio', listener)
   },
 
+  // --- Renderer-side Screen Capture (macOS) ---
+  // AVFoundation's screen input is non-functional on macOS 14+ (Sequoia),
+  // so the screen video is captured in the renderer via getUserMedia
+  // (chromeMediaSource: 'desktop'), streamed as WebM/VP9 chunks to the main
+  // process, and muxed into the final MP4 alongside the optional mic track.
+  getScreenSources: (): Promise<{ id: string; name: string; display_id: string }[]> =>
+    ipcRenderer.invoke('recording:get-screen-sources'),
+  writeScreenVideoChunk: (chunk: ArrayBuffer): Promise<number> =>
+    ipcRenderer.invoke('recording:write-screen-video', chunk),
+  notifyScreenCaptureStopped: (): Promise<void> => ipcRenderer.invoke('recording:screen-capture-stopped'),
+  onStopScreenCapture: (callback: () => void) => {
+    const listener = () => callback()
+    ipcRenderer.on('recorder:stop-screen-capture', listener)
+    return () => ipcRenderer.removeListener('recorder:stop-screen-capture', listener)
+  },
+
   getDisplays: (): Promise<DisplayInfo[]> => ipcRenderer.invoke('desktop:get-displays'),
   getDshowDevices: (): Promise<{ video: DshowDevice[]; audio: DshowDevice[] }> =>
     ipcRenderer.invoke('desktop:get-dshow-devices'),

--- a/package.json
+++ b/package.json
@@ -87,7 +87,6 @@
   },
   "optionalDependencies": {
     "global-mouse-events": "github:tamnguyenvan/global-mouse-events",
-    "iohook-macos": "github:tamnguyenvan/iohook-macos",
     "node-macos-cursor": "github:tamnguyenvan/node-macos-cursor",
     "node-win-cursor": "github:tamnguyenvan/node-win-cursor",
     "x11": "github:tamnguyenvan/node-x11"
@@ -110,7 +109,6 @@
     "asarUnpack": [
       "binaries/**",
       "node_modules/global-mouse-events/**/*",
-      "node_modules/iohook-macos/**/*",
       "node_modules/node-macos-cursor/**/*",
       "node_modules/node-win-cursor/**/*",
       "node_modules/x11/**/*"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "preview": "vite preview",
     "test": "vitest run",
     "test:watch": "vitest",
-    "postinstall": "electron-builder install-app-deps"
+    "patch:electron-info-plist": "node scripts/patch-electron-info-plist.mjs",
+    "postinstall": "electron-builder install-app-deps && node scripts/patch-electron-info-plist.mjs"
   },
   "dependencies": {
     "@radix-ui/react-collapsible": "^1.1.12",
@@ -132,8 +133,10 @@
       "entitlements": "resources/entitlements.mac.plist",
       "entitlementsInherit": "resources/entitlements.mac.plist",
       "extendInfo": {
+        "NSScreenCaptureUsageDescription": "ScreenArc needs to record your computer's screen to capture video.",
         "NSAudioCaptureUsageDescription": "ScreenArc captures system audio so you can include it in your screen recordings.",
-        "NSMicrophoneUsageDescription": "ScreenArc records from the microphone when you enable it during a recording."
+        "NSMicrophoneUsageDescription": "ScreenArc records from the microphone when you enable it during a recording.",
+        "NSCameraUsageDescription": "ScreenArc accesses the camera when you enable webcam capture during a recording."
       },
       "target": [
         {

--- a/scripts/patch-electron-info-plist.mjs
+++ b/scripts/patch-electron-info-plist.mjs
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+// Patches the dev Electron binary's Info.plist with the macOS TCC usage
+// description keys ScreenArc relies on, then ad-hoc re-signs the bundle.
+//
+// Why this exists:
+// - On macOS, an app only appears in System Settings → Privacy & Security
+//   when it both declares the matching NSXxxxUsageDescription string in its
+//   Info.plist *and* invokes the corresponding Apple API at runtime.
+// - The Electron dev binary in node_modules/electron does NOT include
+//   NSScreenCaptureUsageDescription out of the box. Without it, macOS
+//   silently denies Screen Recording, and the dev build never appears in
+//   Privacy & Security at all.
+// - This script runs as part of `npm install`'s postinstall so the keys are
+//   re-applied after every dependency install / Electron upgrade.
+//
+// Side effects:
+// - Modifies node_modules/electron/dist/Electron.app/Contents/Info.plist
+// - Ad-hoc re-signs the .app bundle so macOS will load it after the change
+// - Idempotent: running it twice is safe (uses plutil -replace fall-through)
+//
+// Non-macOS platforms are skipped silently. Errors are logged but don't fail
+// `npm install` because users on Linux/Windows shouldn't be blocked.
+
+import { execFileSync } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import path from 'node:path'
+
+const log = (...args) => console.log('[patch-electron-info-plist]', ...args)
+const warn = (...args) => console.warn('[patch-electron-info-plist]', ...args)
+
+if (process.platform !== 'darwin') {
+  log(`Skipping on ${process.platform} (only meaningful on macOS).`)
+  process.exit(0)
+}
+
+const electronAppPath = path.join(
+  process.cwd(),
+  'node_modules',
+  'electron',
+  'dist',
+  'Electron.app',
+)
+const plistPath = path.join(electronAppPath, 'Contents', 'Info.plist')
+
+if (!existsSync(plistPath)) {
+  warn(`Electron Info.plist not found at ${plistPath} — skipping. Run \`npm install\` first.`)
+  process.exit(0)
+}
+
+log(`Patching ${plistPath}`)
+
+// Strings the user will see in the macOS permission prompts. Match the
+// production build's `extendInfo` in package.json so the dev and packaged
+// builds behave identically.
+const usageStrings = {
+  NSScreenCaptureUsageDescription:
+    "ScreenArc needs to record your computer's screen to capture video.",
+  NSAudioCaptureUsageDescription:
+    'ScreenArc captures system audio so you can include it in your screen recordings.',
+  NSMicrophoneUsageDescription:
+    'ScreenArc records from the microphone when you enable it during a recording.',
+  NSCameraUsageDescription:
+    'ScreenArc accesses the camera when you enable webcam capture during a recording.',
+}
+
+// Identity overrides. Out of the box the dev Electron binary identifies
+// itself as `Electron` with bundle id `com.github.Electron`, so it either
+// (a) doesn't appear at all in System Settings → Privacy & Security under a
+// recognizable name, or (b) collides with every other Electron-based dev
+// tool the user has run. We rename it to "ScreenArc Dev" and give it a
+// project-specific bundle id so it shows up as its own entry — this lets
+// the user revoke or grant Screen Recording / Microphone independently.
+//
+// Note: changing the bundle id means any prior TCC grant (under
+// `com.github.Electron`) does NOT carry over. The user re-grants once.
+const identityOverrides = {
+  CFBundleIdentifier: 'com.screenarc.dev',
+  CFBundleName: 'ScreenArc Dev',
+  CFBundleDisplayName: 'ScreenArc Dev',
+  CFBundleExecutable: 'Electron',
+}
+
+for (const [key, value] of Object.entries({ ...usageStrings, ...identityOverrides })) {
+  // Try -replace first; if the key doesn't exist yet, fall back to -insert.
+  // Both are idempotent in their respective branches.
+  try {
+    execFileSync('plutil', ['-replace', key, '-string', value, plistPath], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    log(`  replaced ${key}`)
+  } catch {
+    try {
+      execFileSync('plutil', ['-insert', key, '-string', value, plistPath], {
+        stdio: ['ignore', 'pipe', 'pipe'],
+      })
+      log(`  inserted ${key}`)
+    } catch (err) {
+      warn(`  failed to set ${key}:`, err?.message ?? err)
+    }
+  }
+}
+
+// Ad-hoc resign so the kernel doesn't reject the modified bundle.
+// Without this, macOS may load the old signed-but-stale Info.plist or refuse
+// to launch the binary. `--force --deep --sign -` is the standard
+// development incantation.
+try {
+  log('Re-signing Electron.app (ad-hoc) so macOS accepts the modified Info.plist...')
+  execFileSync('codesign', ['--force', '--deep', '--sign', '-', electronAppPath], {
+    stdio: ['ignore', 'inherit', 'inherit'],
+  })
+  log('Re-signing complete.')
+} catch (err) {
+  warn('codesign failed — the dev Electron binary may not show in Privacy & Security:')
+  warn(err?.message ?? err)
+}
+
+log('Done. ScreenArc dev build should now register with macOS TCC on next launch.')

--- a/src/lib/screen-capture.ts
+++ b/src/lib/screen-capture.ts
@@ -1,0 +1,243 @@
+// Renderer-side helper for capturing the screen on macOS via Chromium's
+// MediaRecorder, working around the broken FFmpeg avfoundation screen input
+// on macOS 14+ (Sequoia).
+//
+// Pipeline:
+//   1. desktopCapturer.getSources() resolves the user's chosen display.id
+//      to a chromeMediaSourceId.
+//   2. getUserMedia({chromeMediaSource:'desktop',chromeMediaSourceId})
+//      returns a video-only MediaStream backed by ScreenCaptureKit. This
+//      bypasses the system display picker and getDisplayMedia entirely.
+//   3. When the user enabled system audio, we run the existing loopback
+//      flow (enableLoopbackAudio + getDisplayMedia) and graft the audio
+//      track onto the video stream so a single MediaRecorder produces one
+//      WebM file with both video + audio.
+//   4. MediaRecorder writes 1-second WebM clusters; chunks are forwarded
+//      to the main process over IPC and appended to the on-disk file.
+
+const CHUNK_INTERVAL_MS = 1000
+let captureLock: Promise<void> = Promise.resolve()
+
+export interface ScreenCaptureHandle {
+  stop: () => Promise<void>
+  /** True until stop() resolves. Useful for guarding cleanup. */
+  isActive: () => boolean
+  /** True iff a system-audio track was successfully grafted onto the stream. */
+  hasSystemAudio: () => boolean
+}
+
+export interface StartScreenCaptureOptions {
+  /** Selected display.id from the recorder UI. Resolved to a source id. */
+  displayId?: number
+  /** Capture the system-audio loopback alongside the video stream. */
+  includeSystemAudio: boolean
+  /** Bitrate hint forwarded to MediaRecorder for video. Default: 8 Mbps. */
+  videoBitsPerSecond?: number
+  /** Bitrate hint forwarded to MediaRecorder for audio. Default: 128 kbps. */
+  audioBitsPerSecond?: number
+  /** Called if MediaRecorder errors out mid-recording. */
+  onError?: (err: Error) => void
+}
+
+/**
+ * Begin renderer-side screen capture. Returns a handle whose stop() drains
+ * pending chunks before resolving.
+ *
+ * Throws if Screen Recording permission is denied (no sources returned),
+ * MediaRecorder cannot be constructed, or — when system audio was requested —
+ * the loopback flow fails. Caller treats this as fatal and aborts the
+ * recording.
+ */
+export async function startScreenCapture(opts: StartScreenCaptureOptions): Promise<ScreenCaptureHandle> {
+  const api = window.electronAPI
+
+  // Serialize start() across overlapping recordings so two streams never
+  // contend for the loopback flag at once.
+  let releaseLock!: () => void
+  const priorLock = captureLock
+  captureLock = new Promise<void>((resolve) => {
+    releaseLock = resolve
+  })
+
+  let videoStream: MediaStream | null = null
+  let recorder: MediaRecorder | null = null
+  let hasSystemAudio = false
+
+  try {
+    await priorLock
+
+    // 1. Resolve the chosen display to a chromeMediaSourceId. If no displayId
+    //    was provided, fall back to the first screen.
+    const sources = await api.getScreenSources()
+    if (sources.length === 0) {
+      throw new Error('No screen sources available — Screen Recording permission may be denied.')
+    }
+    const targetSource =
+      (opts.displayId !== undefined && sources.find((s) => s.display_id === String(opts.displayId))) ||
+      sources[0]
+
+    // 2. Capture screen video. The cast is required because Chromium's
+    //    legacy chromeMediaSource constraint is not in lib.dom.d.ts.
+    videoStream = await navigator.mediaDevices.getUserMedia({
+      audio: false,
+      video: {
+        mandatory: {
+          chromeMediaSource: 'desktop',
+          chromeMediaSourceId: targetSource.id,
+        },
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any)
+
+    if (!videoStream || videoStream.getVideoTracks().length === 0) {
+      throw new Error('Screen capture returned no video tracks.')
+    }
+
+    // 3. If requested, fetch a system-audio track via the existing loopback
+    //    flow and graft it onto the video stream. We swallow loopback failures
+    //    and fall back to video-only — system audio is always optional.
+    if (opts.includeSystemAudio) {
+      try {
+        await api.enableLoopbackAudio()
+        let loopbackStream: MediaStream | null = null
+        try {
+          loopbackStream = await navigator.mediaDevices.getDisplayMedia({ audio: true, video: true })
+        } finally {
+          await api.disableLoopbackAudio()
+        }
+
+        // Drop the duplicate video track from the loopback stream — we keep
+        // only the audio track and add it to our screen stream.
+        loopbackStream.getVideoTracks().forEach((track) => {
+          try {
+            track.stop()
+          } catch {
+            // ignore
+          }
+          loopbackStream!.removeTrack(track)
+        })
+
+        const audioTrack = loopbackStream.getAudioTracks()[0]
+        if (audioTrack) {
+          videoStream.addTrack(audioTrack)
+          hasSystemAudio = true
+        } else {
+          console.warn('[ScreenCapture] Loopback returned no audio track; continuing without system audio.')
+        }
+      } catch (err) {
+        console.error('[ScreenCapture] System audio loopback failed; continuing without system audio:', err)
+        // Fall through — recording proceeds without system audio.
+      }
+    }
+
+    // 4. Pick a MediaRecorder MIME type. VP9+Opus is preferred (smaller files,
+    //    higher quality); VP8+Opus is the universal fallback.
+    const mimeCandidates = [
+      'video/webm;codecs=vp9,opus',
+      'video/webm;codecs=vp9',
+      'video/webm;codecs=vp8,opus',
+      'video/webm;codecs=vp8',
+      'video/webm',
+    ]
+    const mimeType = mimeCandidates.find((m) => MediaRecorder.isTypeSupported(m)) ?? ''
+
+    const recorderOptions: MediaRecorderOptions = {
+      videoBitsPerSecond: opts.videoBitsPerSecond ?? 8_000_000,
+      audioBitsPerSecond: opts.audioBitsPerSecond ?? 128_000,
+    }
+    if (mimeType) recorderOptions.mimeType = mimeType
+
+    try {
+      recorder = new MediaRecorder(videoStream, recorderOptions)
+    } catch (err) {
+      throw err instanceof Error ? err : new Error(String(err))
+    }
+  } catch (err) {
+    // Roll back: stop tracks, free resources, then rethrow. Do this before
+    // releasing the lock so a follow-up start() sees a clean slate.
+    if (videoStream) videoStream.getTracks().forEach((t) => t.stop())
+    releaseLock()
+    throw err instanceof Error ? err : new Error(String(err))
+  } finally {
+    // The lock guards getDisplayMedia + loopback toggling above. Past this
+    // point the recorder is independent and other captures can start.
+    releaseLock()
+  }
+
+  let active = true
+  const pendingChunkWrites = new Set<Promise<void>>()
+
+  recorder.ondataavailable = async (event: BlobEvent) => {
+    if (!event.data || event.data.size === 0) return
+    const writeTask = (async () => {
+      try {
+        const buf = await event.data.arrayBuffer()
+        await api.writeScreenVideoChunk(buf)
+      } catch (err) {
+        console.error('[ScreenCapture] Failed to forward chunk:', err)
+        // Don't kill the capture on transient IPC failures — the writer
+        // serializes chunks and surfaces hard errors at finalize time.
+      }
+    })()
+
+    pendingChunkWrites.add(writeTask)
+    try {
+      await writeTask
+    } finally {
+      pendingChunkWrites.delete(writeTask)
+    }
+  }
+
+  recorder.onerror = (event: Event) => {
+    const err = (event as unknown as { error?: Error }).error ?? new Error('MediaRecorder error')
+    console.error('[ScreenCapture] MediaRecorder error:', err)
+    active = false
+    opts.onError?.(err)
+  }
+
+  // Emit a chunk every CHUNK_INTERVAL_MS so the main process sees data
+  // continuously and a crash mid-recording leaves only ~1s of video at risk.
+  recorder.start(CHUNK_INTERVAL_MS)
+
+  const stop = async () => {
+    if (!active) return
+    active = false
+
+    if (recorder!.state !== 'inactive') {
+      try {
+        recorder!.requestData()
+      } catch {
+        // requestData throws if not recording; safe to ignore.
+      }
+
+      await new Promise<void>((resolve) => {
+        const onStop = () => {
+          recorder!.removeEventListener('stop', onStop)
+          resolve()
+        }
+        recorder!.addEventListener('stop', onStop)
+        try {
+          recorder!.stop()
+        } catch {
+          resolve()
+        }
+      })
+    }
+
+    videoStream!.getTracks().forEach((t) => {
+      try {
+        t.stop()
+      } catch {
+        // ignore
+      }
+    })
+
+    await Promise.allSettled(Array.from(pendingChunkWrites))
+  }
+
+  return {
+    stop,
+    isActive: () => active,
+    hasSystemAudio: () => hasSystemAudio,
+  }
+}

--- a/src/pages/RecorderPage.tsx
+++ b/src/pages/RecorderPage.tsx
@@ -222,8 +222,7 @@ export function RecorderPage() {
 
       // Set up system-audio capture *before* starting the recording so the TCC
       // permission prompt fires up-front rather than mid-recording. If it fails
-      // (denied, unsupported), we proceed without system audio rather than
-      // blocking the entire recording.
+      // (denied, unsupported), block the recording and tell the user.
       let systemAudioReady = false
       if (wantSystemAudio) {
         try {
@@ -232,8 +231,22 @@ export function RecorderPage() {
           })
           systemAudioReady = true
         } catch (err) {
-          console.error('[Recorder] Could not start system audio capture; proceeding without it.', err)
+          console.error('[Recorder] Could not start system audio capture:', err)
           systemAudioHandleRef.current = null
+          // Disable the toggle so it doesn't keep failing on retry
+          setSystemAudioEnabled(false)
+          window.electronAPI.setSetting('recorder.systemAudioEnabled', false)
+          setActionState('none')
+          setIsRecording(false)
+          window.electronAPI.showMessageBox({
+            type: 'warning',
+            title: 'System Audio Permission Required',
+            message: 'ScreenArc could not access system audio.',
+            detail:
+              'Go to System Settings → Privacy & Security → Screen Recording (macOS 14.3 and earlier) or Microphone (macOS 14.4+) and enable the toggle next to "Electron". Then re-enable System audio in the recorder and try again.',
+            buttons: ['OK'],
+          })
+          return
         }
       }
 
@@ -434,8 +447,14 @@ export function RecorderPage() {
               {supportsSystemAudio && (
                 <button
                   type="button"
-                  onClick={() => {
+                  onClick={async () => {
                     const next = !systemAudioEnabled
+                    if (next) {
+                      // Check permission before enabling; shows a dialog with
+                      // a link to System Settings if not granted.
+                      const status = await window.electronAPI.checkScreenRecordingPermission()
+                      if (status !== 'granted') return
+                    }
                     setSystemAudioEnabled(next)
                     window.electronAPI.setSetting('recorder.systemAudioEnabled', next)
                   }}

--- a/src/pages/RecorderPage.tsx
+++ b/src/pages/RecorderPage.tsx
@@ -20,6 +20,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '.
 import { useDeviceManager } from '../hooks/useDeviceManager'
 import { cn } from '../lib/utils'
 import { startSystemAudioCapture, type SystemAudioCaptureHandle } from '../lib/system-audio'
+import { startScreenCapture, type ScreenCaptureHandle } from '../lib/screen-capture'
 import '../index.css'
 
 // --- Constants ---
@@ -56,9 +57,11 @@ export function RecorderPage() {
   const webcamPreviewRef = useRef<HTMLVideoElement>(null)
   const webcamStreamRef = useRef<MediaStream | null>(null)
   const systemAudioHandleRef = useRef<SystemAudioCaptureHandle | null>(null)
+  const screenCaptureHandleRef = useRef<ScreenCaptureHandle | null>(null)
   const actionInProgressRef = useRef<ActionInProgress>('none')
 
   const supportsSystemAudio = platform === 'darwin'
+  const usesRendererScreenCapture = platform === 'darwin'
   const isBusy = actionInProgress !== 'none'
 
   const setActionState = useCallback((next: ActionInProgress) => {
@@ -72,18 +75,34 @@ export function RecorderPage() {
   useEffect(() => {
     const initialize = async () => {
       try {
-        const [savedWebcamId, savedMicId, savedSystemAudio, savedCursorScale, fetchedDisplays] = await Promise.all([
+        const [savedWebcamId, savedMicId, savedCursorScale, fetchedDisplays] = await Promise.all([
           window.electronAPI.getSetting<string>('recorder.selectedWebcamId'),
           window.electronAPI.getSetting<string>('recorder.selectedMicId'),
-          window.electronAPI.getSetting<boolean>('recorder.systemAudioEnabled'),
           window.electronAPI.getSetting<number>('recorder.cursorScale'),
           window.electronAPI.getDisplays(),
         ])
+        console.info('[Recorder] Loaded saved settings:', {
+          savedWebcamId,
+          savedMicId,
+          savedCursorScale,
+          displayCount: fetchedDisplays.length,
+        })
 
         setSelectedWebcamId(savedWebcamId || 'none')
         setSelectedMicId(savedMicId || 'none')
-        // Only honor a saved value when the platform supports system audio.
-        setSystemAudioEnabled(platform === 'darwin' && !!savedSystemAudio)
+
+        // System-audio capture is intentionally NOT persisted across sessions.
+        // It always starts OFF — the user opts in per session. This avoids the
+        // "I didn't know I was recording system audio" surprise and the stale
+        // state where a stored=true value sticks even after permission is
+        // revoked. We also clear any value left over from an earlier build of
+        // the app that did persist this flag.
+        setSystemAudioEnabled(false)
+        try {
+          await window.electronAPI.setSetting('recorder.systemAudioEnabled', false)
+        } catch (err) {
+          console.warn('[Recorder] Failed to clear legacy systemAudioEnabled setting:', err)
+        }
 
         // Only set cursor scale from settings for Linux
         if (platform === 'linux') {
@@ -96,7 +115,7 @@ export function RecorderPage() {
         const primary = fetchedDisplays.find((d) => d.isPrimary) || fetchedDisplays[0]
         if (primary) setSelectedDisplayId(String(primary.id))
       } catch (error) {
-        console.error('Failed to initialize recorder settings:', error)
+        console.error('[Recorder] Failed to initialize recorder settings:', error)
       }
     }
     initialize()
@@ -124,6 +143,7 @@ export function RecorderPage() {
     const handle = systemAudioHandleRef.current
     systemAudioHandleRef.current = null
     if (handle) {
+      console.info('[Recorder] Stopping system-audio capture handle.')
       try {
         await handle.stop()
       } catch (err) {
@@ -132,26 +152,45 @@ export function RecorderPage() {
     }
   }, [])
 
+  // Best-effort: stop the active screen capture, releasing the screen
+  // MediaStream and flushing the final video chunk.
+  const stopScreenCapture = useCallback(async () => {
+    const handle = screenCaptureHandleRef.current
+    screenCaptureHandleRef.current = null
+    if (handle) {
+      console.info('[Recorder] Stopping screen capture handle.')
+      try {
+        await handle.stop()
+      } catch (err) {
+        console.error('[Recorder] Failed to stop screen capture:', err)
+      }
+    }
+  }, [])
+
   // Effect to manage IPC listeners for recording completion
   useEffect(() => {
     const cleanupStarted = window.electronAPI.onRecordingStarted(() => {
+      console.info('[Recorder] recording-started received from main.')
       setIsRecording(true)
       setActionState('none')
     })
 
     const cleanupFinished = window.electronAPI.onRecordingFinished(() => {
+      console.info('[Recorder] recording-finished received from main.')
       setActionState('none')
       setRecordingState('idle')
       setIsRecording(false)
-      // Recording finished (or canceled) — release the MediaRecorder if it's
-      // still alive. Main process has already finalized the writer.
+      // Recording finished (or canceled) — release any MediaRecorders if
+      // they're still alive. Main process has already finalized the writers.
       void stopSystemAudio()
+      void stopScreenCapture()
       reloadDevices() // Refresh device list in case something changed
     })
 
-    // Main process tells us to stop the MediaRecorder before it finalizes the
-    // writer. We honor it eagerly so the tail chunk is flushed.
+    // Main process tells us to stop the system-audio MediaRecorder before it
+    // finalizes the writer. Honor it eagerly so the tail chunk is flushed.
     const cleanupStopSystemAudio = window.electronAPI.onStopSystemAudio?.(() => {
+      console.info('[Recorder] recorder:stop-system-audio received from main.')
       void (async () => {
         try {
           await stopSystemAudio()
@@ -165,12 +204,29 @@ export function RecorderPage() {
       })()
     })
 
+    // Same dance for the screen-capture MediaRecorder.
+    const cleanupStopScreenCapture = window.electronAPI.onStopScreenCapture?.(() => {
+      console.info('[Recorder] recorder:stop-screen-capture received from main.')
+      void (async () => {
+        try {
+          await stopScreenCapture()
+        } finally {
+          try {
+            await window.electronAPI.notifyScreenCaptureStopped()
+          } catch (error) {
+            console.error('[Recorder] Failed to acknowledge screen-capture stop to main process:', error)
+          }
+        }
+      })()
+    })
+
     return () => {
       cleanupStarted()
       cleanupFinished()
       cleanupStopSystemAudio?.()
+      cleanupStopScreenCapture?.()
     }
-  }, [reloadDevices, setActionState, stopSystemAudio])
+  }, [reloadDevices, setActionState, stopSystemAudio, stopScreenCapture])
 
   // Effect to manage the webcam preview stream
   useEffect(() => {
@@ -220,11 +276,56 @@ export function RecorderPage() {
       const mic = selectedMicId !== 'none' ? mics.find((d) => d.id === selectedMicId) : undefined
       const wantSystemAudio = systemAudioEnabled && supportsSystemAudio
 
+      console.info('[Recorder] handleStart called', {
+        source,
+        selectedDisplayId,
+        platform,
+        usesRendererScreenCapture,
+        wantSystemAudio,
+        hasMic: !!mic,
+        hasWebcam: !!webcam,
+      })
+
+      // On macOS we capture the screen in the renderer because FFmpeg's
+      // avfoundation screen input is broken on macOS 14+. The renderer's
+      // ScreenCaptureKit-backed MediaRecorder writes a single WebM with
+      // optional system audio folded in. Errors here are fatal — without a
+      // screen recording there's nothing to mux.
+      let systemAudioCarriedInScreenStream = false
+      if (usesRendererScreenCapture) {
+        try {
+          screenCaptureHandleRef.current = await startScreenCapture({
+            displayId: source === 'fullscreen' ? Number(selectedDisplayId) : undefined,
+            includeSystemAudio: wantSystemAudio,
+            onError: (err) => console.error('[Recorder] Screen capture failed mid-recording:', err),
+          })
+          systemAudioCarriedInScreenStream = screenCaptureHandleRef.current.hasSystemAudio()
+          console.info('[Recorder] Screen capture started.', {
+            hasSystemAudioInStream: systemAudioCarriedInScreenStream,
+          })
+        } catch (err) {
+          console.error('[Recorder] Could not start screen capture:', err)
+          screenCaptureHandleRef.current = null
+          setActionState('none')
+          setIsRecording(false)
+          window.electronAPI.showMessageBox({
+            type: 'warning',
+            title: 'Screen Recording Permission Required',
+            message: 'ScreenArc could not access the screen.',
+            detail:
+              'Go to System Settings → Privacy & Security → Screen Recording, enable the toggle next to "Electron" (the dev build), then restart the app and try again.',
+            buttons: ['OK'],
+          })
+          return
+        }
+      }
+
       // Set up system-audio capture *before* starting the recording so the TCC
-      // permission prompt fires up-front rather than mid-recording. If it fails
-      // (denied, unsupported), block the recording and tell the user.
-      let systemAudioReady = false
-      if (wantSystemAudio) {
+      // permission prompt fires up-front rather than mid-recording. On macOS
+      // the screen capture above already grabbed system audio, so we skip the
+      // separate system-audio capture path.
+      let systemAudioReady = systemAudioCarriedInScreenStream
+      if (wantSystemAudio && !usesRendererScreenCapture) {
         try {
           systemAudioHandleRef.current = await startSystemAudioCapture({
             onError: (err) => console.error('[Recorder] System audio capture failed mid-recording:', err),
@@ -236,6 +337,7 @@ export function RecorderPage() {
           // Disable the toggle so it doesn't keep failing on retry
           setSystemAudioEnabled(false)
           window.electronAPI.setSetting('recorder.systemAudioEnabled', false)
+          await stopScreenCapture()
           setActionState('none')
           setIsRecording(false)
           window.electronAPI.showMessageBox({
@@ -250,6 +352,14 @@ export function RecorderPage() {
         }
       }
 
+      console.info('[Recorder] Calling main.startRecording with', {
+        source,
+        displayId: source === 'fullscreen' ? Number(selectedDisplayId) : undefined,
+        hasWebcam: !!webcam,
+        hasMic: !!mic,
+        systemAudio: systemAudioReady,
+      })
+
       const result = await window.electronAPI.startRecording({
         source,
         displayId: source === 'fullscreen' ? Number(selectedDisplayId) : undefined,
@@ -259,15 +369,18 @@ export function RecorderPage() {
       })
 
       if (result.canceled) {
+        console.warn('[Recorder] main.startRecording returned canceled.')
         // If the user canceled (or main returned canceled), make sure we don't
-        // leak the system-audio MediaRecorder we already started.
+        // leak the MediaRecorders we already started.
         await stopSystemAudio()
+        await stopScreenCapture()
         setActionState('none')
         setIsRecording(false)
       }
     } catch (error) {
-      console.error('Failed to start recording:', error)
+      console.error('[Recorder] Failed to start recording:', error)
       await stopSystemAudio()
+      await stopScreenCapture()
       setActionState('none')
       setIsRecording(false)
     }
@@ -443,20 +556,28 @@ export function RecorderPage() {
                 </SelectContent>
               </Select>
 
-              {/* System Audio Toggle (macOS only) */}
+              {/* System Audio Toggle (macOS only) — session-local, not persisted. */}
               {supportsSystemAudio && (
                 <button
                   type="button"
                   onClick={async () => {
                     const next = !systemAudioEnabled
+                    console.info(`[Recorder] System-audio toggle clicked. next=${next}`)
                     if (next) {
-                      // Check permission before enabling; shows a dialog with
-                      // a link to System Settings if not granted.
-                      const status = await window.electronAPI.checkScreenRecordingPermission()
+                      // Check permission before enabling. If not granted, the
+                      // main process pops a dialog with a link to System
+                      // Settings → Privacy & Security → Screen Recording, and
+                      // we leave the toggle off until the user retries.
+                      let status: 'granted' | 'denied' | 'not-determined' = 'denied'
+                      try {
+                        status = await window.electronAPI.checkScreenRecordingPermission()
+                      } catch (err) {
+                        console.error('[Recorder] checkScreenRecordingPermission threw:', err)
+                      }
+                      console.info(`[Recorder] Screen recording permission status: ${status}`)
                       if (status !== 'granted') return
                     }
                     setSystemAudioEnabled(next)
-                    window.electronAPI.setSetting('recorder.systemAudioEnabled', next)
                   }}
                   disabled={isRecording || isBusy}
                   aria-pressed={systemAudioEnabled}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,7 +7,7 @@ import { nodePolyfills } from 'vite-plugin-node-polyfills'
 
 // Native modules that need to be externalized for proper runtime loading
 // Fix for #137: global-mouse-events not loading on Windows
-const nativeModules = ['global-mouse-events', 'iohook-macos', 'node-macos-cursor', 'node-win-cursor', 'x11']
+const nativeModules = ['global-mouse-events', 'node-macos-cursor', 'node-win-cursor', 'x11']
 
 // https://vitejs.dev/config/
 export default defineConfig({


### PR DESCRIPTION
Follow-up to #155. Fixes issues found during local testing on macOS 15 Sequoia, and replaces the broken AVFoundation screen capture pipeline with a ScreenCaptureKit-based renderer-side approach.

## Screen capture: AVFoundation → ScreenCaptureKit

**Problem:** `AVCaptureScreenInput` (FFmpeg's `avfoundation` device) was deprecated in macOS 14 and is **non-functional on macOS 15 (Sequoia)**. Every recording fails with `Input/output error` — screen recording is completely broken on the two most recent macOS versions.

**Fix:** Replaced with a renderer-side ScreenCaptureKit pipeline that mirrors how system audio is captured:

1. `getDisplayMedia({ video: true })` in the renderer → `MediaRecorder` (VP8/WebM) → 1-second chunk IPC → `ScreenVideoWriter` in main → `<id>-screen.webm`
2. On stop: `ScreenVideoWriter.finalize()` → FFmpeg transcodes WebM → MP4 (H.264/AAC) → existing audio mux runs as before.

Uses the same TCC grant already covering `desktopCapturer` and system audio. No new permission required.

**New files:**
- `src/lib/screen-capture.ts` — renderer capture module (lock-guarded, 1-second WebM chunks over IPC)
- `electron/main/features/screen-video-writer.ts` — append-only chunk writer with serialized promise queue
- `electron/main/features/screen-video-writer.test.ts` — 13 unit tests
- `scripts/patch-electron-info-plist.mjs` — dev-build helper: injects usage description keys into Electron's `Info.plist` and re-signs (ad-hoc) so the binary registers with macOS TCC during development
- `package.json` — adds `patch:electron-info-plist` npm script

**Modified:**
- `recording-manager.ts` — `startRecording()` triggers renderer-side capture; `cleanupAndSave()` waits for `ScreenVideoWriter.finalize()` then calls `buildMacMuxArgs()`
- `build-mux-args.ts` / `.test.ts` — added `buildMacMuxArgs()` for VP8→H.264 transcode + audio mix (8 new test cases)
- `ipc/handlers/recording.ts`, `ipc/index.ts` — `recording:write-screen-video`, `recording:stop-screen-capture` handlers
- `state.ts` — `RecordingSession` gains `screenWebmPath?: string`
- `editor-window.ts`, `preload.ts`, `RecorderPage.tsx` — wired through the new capture lifecycle

---

## Stop/save hang

**Problem:** When avfoundation fails, FFmpeg exits immediately with code 1. A subsequent `cleanupAndSave()` adds a `close` listener to an already-dead process — the Promise never resolves and the app hangs on "Saving...".

**Fix:** Check `ffmpeg.exitCode !== null` before waiting on `close`; resolve immediately if already exited.

**Problem:** `muxSystemAudio()` ran even when `screen.mp4` was never created, producing a confusing ffmpeg error and a misleading validation failure dialog.

**Fix:** Early `stat` check — if `screenVideoPath` doesn't exist, skip the mux and clean up the system audio file silently.

---

## Screen recording permission detection

**Problem:** `systemPreferences.getMediaAccessStatus('screen')` always returns `'granted'` on macOS 14+ regardless of actual TCC state.

**Fix:** Replaced with a `desktopCapturer.getSources()` probe — empty result means denied. Only reliable runtime check on modern macOS.

**Problem:** The Electron dev binary never appeared in System Settings → Screen Recording because no ScreenCaptureKit call had been made at startup.

**Fix:** Call `desktopCapturer.getSources()` once at app startup to register the binary with macOS TCC.

---

## System audio toggle guard

**Problem:** Toggling system audio on silently succeeded regardless of permission; if `startSystemAudioCapture()` then failed at recording start, the app fell back to no system audio with no user feedback.

**Fix:**
- Toggle-to-enable now calls `checkScreenRecordingPermission` (IPC), which probes via `desktopCapturer` and, if denied, shows a dialog with an **Open Settings** button deep-linking to `System Settings → Privacy → Screen Recording`.
- If `startSystemAudioCapture()` throws at recording start, recording is aborted, the toggle auto-disables, and an actionable error dialog is shown.

---

## Mouse tracking startup dialog

**Problem:** When `iohook-macos` fails to load (no prebuilt for current Electron ABI), a blocking `showErrorBox` dialog appeared at startup, preventing any testing.

**Fix:** Replaced with `log.warn` — mouse tracking is non-critical.

---

## New IPC surface

| Channel | Direction | Purpose |
|---|---|---|
| `recording:write-screen-video` | renderer → main | Stream VP8/WebM screen capture chunks |
| `recording:stop-screen-capture` | main → renderer | Signal renderer to stop screen capture |
| `permission:check-screen-recording` | renderer → main | Probe TCC; show dialog + Open Settings if denied |
| `dialog:showMessageBox` | renderer → main | Generic message box |

---

## Test plan

- [ ] `npm run patch:electron-info-plist` (first time after `npm install`)
- [ ] `npm run dev` — app launches without errors
- [ ] Grant Screen Recording permission when prompted (or verify it works silently on Sequoia)
- [ ] Start a recording — `<id>-screen.webm` appears in `~/.screenarc/` within 1–2 s
- [ ] Stop recording — FFmpeg transcodes WebM → MP4; editor opens with video
- [ ] With system audio enabled: muxed output contains both video and audio tracks
- [ ] With mic + system audio: all three streams mixed correctly
- [ ] Cancel mid-recording — no orphan `.webm` files
- [ ] Permission denied: toggle shows dialog with Open Settings button
- [ ] `npm test` → all tests pass (28 total: 15 original + 13 new)