### PR TITLE
fix: overwrite stale recording outputs

### DIFF
--- a/electron/main/features/build-recording-args.test.ts
+++ b/electron/main/features/build-recording-args.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from 'vitest'
+import { buildFfmpegArgs } from './build-recording-args'
+
+describe('buildFfmpegArgs', () => {
+  test('overwrites stale recording outputs without prompting', () => {
+    const args = buildFfmpegArgs(
+      ['-f', 'gdigrab', '-i', 'desktop'],
+      false,
+      false,
+      'ScreenArc-recording-screen.mp4',
+    )
+
+    expect(args[0]).toBe('-y')
+    expect(args).toContain('ScreenArc-recording-screen.mp4')
+  })
+})

--- a/electron/main/features/build-recording-args.ts
+++ b/electron/main/features/build-recording-args.ts
@@ -1,0 +1,50 @@
+/**
+ * Builds FFmpeg arguments for screen, microphone, and webcam capture.
+ */
+export function buildFfmpegArgs(
+  inputArgs: string[],
+  hasWebcam: boolean,
+  hasMic: boolean,
+  screenOut: string,
+  webcamOut?: string,
+): string[] {
+  // Recording output paths can survive a failed attempt. FFmpeg is spawned
+  // without an interactive terminal, so overwrite them instead of waiting for
+  // a confirmation that can never arrive.
+  const finalArgs = ['-y', ...inputArgs]
+  const micIndex = hasMic ? 0 : -1
+  const webcamIndex = hasMic ? (hasWebcam ? 1 : -1) : hasWebcam ? 0 : -1
+  const screenIndex = (hasMic ? 1 : 0) + (hasWebcam ? 1 : 0)
+
+  finalArgs.push(
+    '-map',
+    `${screenIndex}:v`,
+    '-c:v',
+    'libx264',
+    '-preset',
+    'ultrafast',
+    '-pix_fmt',
+    'yuv420p',
+    screenOut,
+  )
+
+  if (hasMic) {
+    finalArgs.push('-map', `${micIndex}:a`, '-c:a', 'aac', '-b:a', '192k', screenOut)
+  }
+
+  if (hasWebcam && webcamOut) {
+    finalArgs.push(
+      '-map',
+      `${webcamIndex}:v`,
+      '-c:v',
+      'libx264',
+      '-preset',
+      'ultrafast',
+      '-pix_fmt',
+      'yuv420p',
+      webcamOut,
+    )
+  }
+
+  return finalArgs
+}

--- a/electron/main/features/recording-manager.ts
+++ b/electron/main/features/recording-manager.ts
@@ -17,6 +17,7 @@ import type { RecordingSession, RecordingGeometry } from '../state'
 import { SystemAudioWriter } from './system-audio-writer'
 import { ScreenVideoWriter } from './screen-video-writer'
 import { buildMuxArgs, buildMacMuxArgs } from './build-mux-args'
+import { buildFfmpegArgs } from './build-recording-args'
 
 const FFMPEG_PATH = getFFmpegPath()
 const SYSTEM_AUDIO_STOP_TIMEOUT_MS = 5000
@@ -365,59 +366,6 @@ async function startActualRecording(
 
   createTray()
   return { canceled: false, ...appState.currentRecordingSession }
-}
-
-/**
- * Constructs the final FFmpeg command arguments by mapping input streams to output files.
- */
-function buildFfmpegArgs(
-  inputArgs: string[],
-  hasWebcam: boolean,
-  hasMic: boolean,
-  screenOut: string,
-  webcamOut?: string,
-): string[] {
-  const finalArgs = [...inputArgs]
-  // Determine the index of each input stream (mic, webcam, screen)
-  const micIndex = hasMic ? 0 : -1
-  const webcamIndex = hasMic ? (hasWebcam ? 1 : -1) : hasWebcam ? 0 : -1
-  const screenIndex = (hasMic ? 1 : 0) + (hasWebcam ? 1 : 0)
-
-  // Map screen video stream
-  finalArgs.push(
-    '-map',
-    `${screenIndex}:v`,
-    '-c:v',
-    'libx264',
-    '-preset',
-    'ultrafast',
-    '-pix_fmt',
-    'yuv420p',
-    screenOut,
-  )
-
-  // Map audio stream if present - must specify output file (screenOut)
-  // Fix for #130: Audio was being routed to webcam file instead of screen file
-  if (hasMic) {
-    finalArgs.push('-map', `${micIndex}:a`, '-c:a', 'aac', '-b:a', '192k', screenOut)
-  }
-
-  // Map webcam video stream if present (video only, no audio)
-  if (hasWebcam && webcamOut) {
-    finalArgs.push(
-      '-map',
-      `${webcamIndex}:v`,
-      '-c:v',
-      'libx264',
-      '-preset',
-      'ultrafast',
-      '-pix_fmt',
-      'yuv420p',
-      webcamOut,
-    )
-  }
-
-  return finalArgs
 }
 
 /**


### PR DESCRIPTION
## Summary

- add FFmpeg's `-y` global option to screen recording commands
- extract recording argument construction into a focused, testable module
- add a regression test covering stale recording output files

## Root cause

When a temporary recording MP4 already existed, FFmpeg prompted for overwrite confirmation. ScreenArc runs FFmpeg without an interactive terminal, so the confirmation could not be supplied. FFmpeg exited without writing video data, after which recording validation reported a 0-byte file.

Adding `-y` makes recording output replacement deterministic and consistent with the existing post-recording mux and export commands.

Fixes #152.

## Validation

- `npm.cmd test` — 30 tests passed
- `npm.cmd run lint` — passed
- `npm.cmd run build` — passed
